### PR TITLE
Adds size and version to file display

### DIFF
--- a/app/models/dds-resource.js
+++ b/app/models/dds-resource.js
@@ -7,5 +7,8 @@ export default DS.Model.extend({
   name: DS.attr('string'),
   isFile: Ember.computed('kind', function() { return this.get('kind') === DDSKinds.file; }),
   isFolder: Ember.computed('kind', function() { return this.get('kind') === DDSKinds.folder; }),
-  project: DS.belongsTo('dds-project')
+  project: DS.belongsTo('dds-project'),
+  size: DS.attr('number'),
+  version: DS.attr('number'),
+  version_id: DS.attr('string'),
 });

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -39,3 +39,27 @@ ul.tree li:last-child:before {
 .dds-resource-node {
   cursor: pointer;
 }
+
+.dds-resource-file-details:before {
+  content: "(";
+}
+
+.dds-resource-file-details:after{
+  content: ")";
+}
+
+.dds-resource-file-details span:after {
+  content: ", ";
+}
+
+.dds-resource-file-details span:last-child:after {
+  content: "";
+}
+
+.dds-resource-file-version:before {
+  content: "v";
+}
+
+.dds-resource-file-details {
+  font-style: italic;
+}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -40,26 +40,6 @@ ul.tree li:last-child:before {
   cursor: pointer;
 }
 
-.dds-resource-file-details:before {
-  content: "(";
-}
-
-.dds-resource-file-details:after{
-  content: ")";
-}
-
-.dds-resource-file-details span:after {
-  content: ", ";
-}
-
-.dds-resource-file-details span:last-child:after {
-  content: "";
-}
-
-.dds-resource-file-version:before {
-  content: "v";
-}
-
 .dds-resource-file-details {
   font-style: italic;
 }

--- a/app/templates/components/dds/dds-resource-node.hbs
+++ b/app/templates/components/dds/dds-resource-node.hbs
@@ -6,7 +6,6 @@
 <span class="dds-resource-name">{{resource.name}}</span>
 {{#if resource.isFile}}
   <span class="dds-resource-file-details">
-    <span class="dds-resource-file-size">{{number-to-human-size resource.size}}</span>
-    <span class="dds-resource-file-version">{{resource.version}}</span>
+    (<span class="dds-resource-file-size">{{number-to-human-size resource.size}}</span>, v<span class="dds-resource-file-version">{{resource.version}}</span>)
   </span>
 {{/if}}

--- a/app/templates/components/dds/dds-resource-node.hbs
+++ b/app/templates/components/dds/dds-resource-node.hbs
@@ -4,3 +4,9 @@
   {{dds.dds-file-checkbox resource pickedResources}}
 {{/if}}
 <span class="dds-resource-name">{{resource.name}}</span>
+{{#if resource.isFile}}
+  <span class="dds-resource-file-details">
+    <span class="dds-resource-file-size">{{number-to-human-size resource.size}}</span>
+    <span class="dds-resource-file-version">{{resource.version}}</span>
+  </span>
+{{/if}}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ember-data": "^2.9.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
+    "ember-number-to-human-size": "0.3.0",
     "ember-radio-buttons": "4.0.3",
     "ember-resolver": "^2.0.3",
     "ember-simple-auth": "1.1.0",


### PR DESCRIPTION
- Brings in ember-number-to-human-size to format bytes in human-readable format
- abuses CSS before/after/content rules to put parenthesis and commas

Fixes #6 