### PR TITLE
Fix dds-file-picker display bug

### DIFF
--- a/app/components/dds/dds-file-picker.js
+++ b/app/components/dds/dds-file-picker.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 const DDSFilePicker = Ember.Component.extend({
+  project: null,
   store: Ember.inject.service(), // Needs access to store to query for children
   resources: [], // Can be files or folders
   pickedFiles: [],
@@ -16,13 +17,17 @@ const DDSFilePicker = Ember.Component.extend({
       this.get('filesChanged')();
     }
   },
-  projectChanged: Ember.observer('project', function() {
+  projectChanged: Ember.on('init', Ember.observer('project', function() {
+    if(! this.get('project.id')) {
+      Ember.Logger.log('bailing out');
+      return;
+    }
     this.get('store').query('dds-resource', {
       project_id: this.get('project.id')
     }).then((resources) => {
       this.set('resources', resources);
     });
-  })
+  }))
 });
 
 DDSFilePicker.reopenClass({

--- a/app/templates/components/dds/dds-file-picker.hbs
+++ b/app/templates/components/dds/dds-file-picker.hbs
@@ -1,6 +1,6 @@
 <ul class="tree list-unstyled">
 {{#each resources as |resource|}}
-  {{dds.dds-resource-tree resource pickedFiles (action 'toggleFile')}}
+  <li class="dds-resource-list-item">{{dds.dds-resource-tree resource pickedFiles (action 'toggleFile')}}</li>
 {{/each}}
 </ul>
 {{yield}}


### PR DESCRIPTION
- Wraps the top-level dds-resource-tree elements in `<li>` tag (they were already children of a `<ul>`)
- Updates the dds-file-picker to load files if instantiated with a project (by default, ember obervers don't fire on init, only on change after init)

Fixes #1 