### PR TITLE
Adds bespin-job-watcher service to job-details component

### DIFF
--- a/app/components/job-detail.js
+++ b/app/components/job-detail.js
@@ -1,8 +1,10 @@
 import Ember from 'ember';
 
 const JobDetail = Ember.Component.extend({
+  watcher: Ember.inject.service('bespin-job-watcher'),
+  session: Ember.inject.service('session'),
+  socketRef: null,
   job: null,
-  jobErrors: [],
   indent: 2,
   prettyJobOrder: Ember.computed('job.jobOrder', 'indent', function() {
     try {
@@ -10,11 +12,41 @@ const JobDetail = Ember.Component.extend({
     } catch(e)  { // May not be valid JSON
       return this.get('job.jobOrder');
     }
-  })
+  }),
+  getAuthToken() {
+    var authData = this.get('session.data');
+    if (authData && authData.authenticated) {
+      return authData.authenticated.token;
+    }
+    return '';
+  },
+  getJobId() {
+    var job = this.get('job');
+    if (job) {
+      return job.get('id');
+    }
+    return '';
+  },
+  didInsertElement() {
+    this._super(...arguments);
+    var watcher = this.get('watcher');
+    var token = this.getAuthToken();
+    var jobId = this.getJobId();
+    watcher.startWatching(token, jobId);
+  },
+  willDestroyElement() {
+    this._super(...arguments);
+    var watcher = this.get('watcher');
+    var token = this.getAuthToken();
+    var jobId = this.getJobId();
+    if (watcher) {
+      watcher.stopWatching(token, jobId);
+    }
+  }
 });
 
 JobDetail.reopenClass({
-  positionalParams: ['job', 'jobErrors']
+  positionalParams: ['job']
 });
 
 export default JobDetail;

--- a/app/components/job-detail.js
+++ b/app/components/job-detail.js
@@ -13,31 +13,24 @@ const JobDetail = Ember.Component.extend({
     }
   }),
   getAuthToken() {
-    var authData = this.get('session.data');
+    const authData = this.get('session.data');
     if (authData && authData.authenticated) {
       return authData.authenticated.token;
     }
     return '';
   },
-  getJobId() {
-    var job = this.get('job');
-    if (job) {
-      return job.get('id');
-    }
-    return '';
-  },
   didInsertElement() {
     this._super(...arguments);
-    var watcher = this.get('watcher');
-    var token = this.getAuthToken();
-    var jobId = this.getJobId();
+    const watcher = this.get('watcher');
+    const token = this.getAuthToken();
+    const jobId = this.get('job.id');
     watcher.startWatching(token, jobId);
   },
   willDestroyElement() {
     this._super(...arguments);
-    var watcher = this.get('watcher');
-    var token = this.getAuthToken();
-    var jobId = this.getJobId();
+    const watcher = this.get('watcher');
+    const token = this.getAuthToken();
+    const jobId = this.get('job.id');
     if (watcher) {
       watcher.stopWatching(token, jobId);
     }

--- a/app/components/job-detail.js
+++ b/app/components/job-detail.js
@@ -3,7 +3,6 @@ import Ember from 'ember';
 const JobDetail = Ember.Component.extend({
   watcher: Ember.inject.service('bespin-job-watcher'),
   session: Ember.inject.service('session'),
-  socketRef: null,
   job: null,
   indent: 2,
   prettyJobOrder: Ember.computed('job.jobOrder', 'indent', function() {

--- a/app/models/job-error.js
+++ b/app/models/job-error.js
@@ -4,5 +4,5 @@ export default DS.Model.extend({
   content: DS.attr('string'),
   jobStep: DS.attr('string'),
   created: DS.attr('date'),
-  job: DS.belongsTo('job', { inverse: null})
+  job: DS.belongsTo('job')
 });

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -19,6 +19,7 @@ export default DS.Model.extend({
     return this.get('state') === 'F';
   }),
   outputDir: DS.belongsTo('job-output-dir'),
+  // Named jobErrors because DS.Model already has an errors property (contains validation error messages)
   jobErrors: DS.hasMany('job-error'),
   updateAfterAction(data) {
     // The action methods respond with an updated job, so we must update the local store

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -19,6 +19,7 @@ export default DS.Model.extend({
     return this.get('state') === 'F';
   }),
   outputDir: DS.belongsTo('job-output-dir'),
+  jobErrors: DS.hasMany('job-error'),
   updateAfterAction(data) {
     // The action methods respond with an updated job, so we must update the local store
     // with that payload. Remember, pushPayload doesn't return.

--- a/app/routes/jobs/show.js
+++ b/app/routes/jobs/show.js
@@ -3,24 +3,5 @@ import Ember from 'ember';
 export default Ember.Route.extend({
   model(params) {
     return this.get('store').findRecord('job', params.job_id);
-  },
-  setupController(controller, job) {
-    /*
-      Previously model() returned a hash, to fetch the job and jobErrors together.
-
-      However, this is not compatible with typical {{link-to}} behavior. link-to takes the model object (job)
-      as an argument, generates a URL from its ID, and then uses that object as the model when clicking on
-      the link. So it doesn't call our model() hook, nor does it pass a hash of {job, errors} as the hook did.
-
-      So it's more consistent for the job to be the single, primary model on this route, and load the errors after
-      the model is fulfilled.
-     */
-    this._super(controller, job);
-    // Fetch the job errors
-    this.get('store').query('job-error', {
-      job: job.get('id')
-    }).then((jobErrors) => {
-      controller.set('jobErrors', jobErrors);
-    });
   }
 });

--- a/app/serializers/job.js
+++ b/app/serializers/job.js
@@ -3,6 +3,8 @@ import DS from 'ember-data';
 
 export default ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
   attrs: {
-    outputDir: {embedded: 'always'}
-  }
+    outputDir: {embedded: 'always'},
+    jobErrors: {embedded: 'always'}
+  },
+
 });

--- a/app/services/bespin-job-watcher.js
+++ b/app/services/bespin-job-watcher.js
@@ -1,0 +1,80 @@
+/**
+ * Service used to update jobs based on messages from a websocket.
+ * Users should call startWatching to
+ * Websocket host determined by ENV.APP.JOB_WATCHER_HOST.
+ */
+import Ember from 'ember';
+import ENV from 'bespin-ui/config/environment'; // This is how we load config variables from our environment.js file
+
+function buildRequest(command, token, jobId) {
+  return JSON.stringify({
+    "command": command,
+    "token": token,
+    "job": jobId
+  });
+}
+
+function parseResponse(response) {
+  return JSON.parse(response);
+}
+
+function startWatchingJob(socket, token, jobId) {
+  socket.send(buildRequest("add", token, jobId));
+}
+
+function stopWatchingJob(socket, token, jobId) {
+  socket.send(buildRequest("remove", token, jobId));
+}
+
+export default Ember.Service.extend({
+  store: Ember.inject.service(),
+  websockets: Ember.inject.service(),
+  socketRef: null,
+  startWatching(token, jobId) {
+    var socket = this.get('socketRef');
+    if (socket) {
+      startWatchingJob(socket, token, jobId);
+    } else {
+      var url = 'wss://' + ENV.APP.JOB_WATCHER_HOST + '/';
+      socket = this.get('websockets').socketFor(url);
+      socket.on('open', function () {
+        startWatchingJob(socket, token, jobId);
+      }, this);
+      socket.on('message', this.onMessage, this);
+      socket.on('close', this.onClose, this);
+      this.set('socketRef', socket);
+    }
+  },
+  stopWatching(token, jobId) {
+    var socket = this.get('socketRef');
+    if (socket) {
+      stopWatchingJob(socket, token, jobId);
+    } else {
+      console.log("Job watcher websocket not connected.");
+    }
+  },
+  onMessage(event) {
+    var response = parseResponse(event.data);
+    if (response.status === "ok") {
+      var store = this.get('store');
+      var jobData = response.data;
+
+      store.findRecord('job', jobData.job, {}).then(function (job) {
+        job.reload();
+      });
+    } else {
+      console.log("Job Watcher Error:", response.data.message);
+    }
+  },
+  onClose() {
+    const socket = this.get('socketRef');
+    if (socket) {
+      socket.off('open', this.myOpenHandler);
+      socket.off('message', this.myMessageHandler);
+      socket.off('close', this.myCloseHandler);
+    }
+  },
+  willDestroy() {
+    this.onClose();
+  }
+});

--- a/app/services/bespin-job-watcher.js
+++ b/app/services/bespin-job-watcher.js
@@ -35,7 +35,7 @@ export default Ember.Service.extend({
     if (socket) {
       startWatchingJob(socket, token, jobId);
     } else {
-      var url = 'wss://' + ENV.APP.JOB_WATCHER_HOST + '/';
+      var url = ENV.APP.JOB_WATCHER_HOST;
       socket = this.get('websockets').socketFor(url);
       socket.on('open', function () {
         startWatchingJob(socket, token, jobId);

--- a/app/templates/components/job-detail.hbs
+++ b/app/templates/components/job-detail.hbs
@@ -19,11 +19,11 @@
             <dt>Results</dt>
             <dd class="job-results"><a class="job-results-link" href="{{output-dir-link job.outputDir}}">{{job.outputDir.project.name}}/{{job.outputDir.dirName}}</a></dd>
           {{/if}}
-          {{#if jobErrors}}
-            <dt>Errors</dt>
-            {{#each jobErrors as |jobError|}}
-              <dd class="job-error"><pre>{{jobError.content}}</pre></dd>
-            {{/each}}
+          {{#if job.jobErrors}}
+              <dt>Errors</dt>
+              {{#each job.jobErrors as |jobError|}}
+                  <dd class="job-error"><pre>{{jobError.content}}</pre></dd>
+              {{/each}}
           {{/if}}
           <dt>Step</dt>
           <dd class="job-step">{{decode-job-step job.step}}</dd>

--- a/app/templates/jobs/show.hbs
+++ b/app/templates/jobs/show.hbs
@@ -1,2 +1,2 @@
-{{job-detail model jobErrors}}
+{{job-detail model}}
 {{outlet}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -31,6 +31,7 @@ module.exports = function(environment) {
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
     ENV.APP.API_HOST = 'http://127.0.0.1:8000';
     ENV.APP.API_NAMESPACE = 'api';
+    ENV.APP.JOB_WATCHER_HOST = 'localhost:8080';
   }
 
   if (environment === 'test') {

--- a/config/environment.js
+++ b/config/environment.js
@@ -31,7 +31,7 @@ module.exports = function(environment) {
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
     ENV.APP.API_HOST = 'http://127.0.0.1:8000';
     ENV.APP.API_NAMESPACE = 'api';
-    ENV.APP.JOB_WATCHER_HOST = 'localhost:8080';
+    ENV.APP.JOB_WATCHER_HOST = 'wss://localhost:8080';
   }
 
   if (environment === 'test') {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ember-radio-buttons": "4.0.3",
     "ember-resolver": "^2.0.3",
     "ember-simple-auth": "1.1.0",
+    "ember-websockets": "7.0.1",
     "emberx-select": "3.0.0",
     "loader.js": "^4.0.10"
   }

--- a/tests/integration/components/job-detail-test.js
+++ b/tests/integration/components/job-detail-test.js
@@ -2,6 +2,11 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
+const bespinJobWatcherStub = Ember.Service.extend({
+  startWatching() {},
+  stopWatching() {}
+});
+
 moduleForComponent('job-detail', 'Integration | Component | job detail', {
   integration: true,
   beforeEach() {
@@ -18,10 +23,15 @@ moduleForComponent('job-detail', 'Integration | Component | job detail', {
       outputDir: Ember.Object.create({
         project: {id: 'abv-123', name: 'project-name'},
         dirName: 'results-dir'
-      })
+      }),
+      jobErrors: [
+        {content:"Error 1"},
+        {content:"Error 2"},
+      ]
     });
     this.set('job', job);
     this.set('jobErrors', []);
+    this.register('service:bespin-job-watcher', bespinJobWatcherStub);
   }
 });
 
@@ -59,11 +69,7 @@ test('it pretty-prints JSON', function(assert) {
 });
 
 test('it shows errors', function (assert) {
-  this.set('jobErrors', [
-    {content: 'Error 1'},
-    {content: 'Error 2'}
-  ]);
-  this.render(hbs`{{job-detail job jobErrors}}`);
+  this.render(hbs`{{job-detail job}}`);
   assert.equal(this.$('.job-error').length, 2);
   assert.equal(this.$('.job-error:eq(0)').text(), 'Error 1');
   assert.equal(this.$('.job-error:eq(1)').text(), 'Error 2');

--- a/tests/unit/models/job-test.js
+++ b/tests/unit/models/job-test.js
@@ -6,7 +6,8 @@ moduleForModel('job', 'Unit | Model | job', {
   // Specify the other units that are required for this test.
   needs: [
     'model:workflow-version',
-    'model:job-output-dir'
+    'model:job-output-dir',
+    'model:job-error',
   ]
 });
 

--- a/tests/unit/services/bespin-job-watcher-test.js
+++ b/tests/unit/services/bespin-job-watcher-test.js
@@ -1,0 +1,123 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:bespin-job-watcher', 'Unit | Service | bespin job watcher', {});
+
+// Replace this with your real tests.
+test('startWatching wll send add command', function (assert) {
+  var onOpenCalled = false;
+  var afterOpenFunc = null;
+  var sendPayload = null;
+
+  function socketFor() {
+    onOpenCalled = true;
+    return {
+      on(msg, func) {
+        if (msg === 'open') {
+          afterOpenFunc = func;
+        }
+      },
+      off() {
+      },
+      send(payload) {
+        sendPayload = JSON.parse(payload);
+      }
+    };
+  }
+
+  let service = this.subject({
+    'websockets': {
+      'socketFor': socketFor
+    }
+  });
+  assert.ok(service);
+  //first time we should open
+  service.startWatching('abcdef', '123');
+  assert.equal(true, onOpenCalled);
+  afterOpenFunc();
+  assert.equal("add", sendPayload.command);
+  assert.equal("abcdef", sendPayload.token);
+  assert.equal("123", sendPayload.job);
+
+  //second time it should send without calling open or using a callback
+  onOpenCalled = false;
+  service.startWatching('bcedf', '124');
+  assert.equal(false, onOpenCalled);
+  assert.equal("add", sendPayload.command);
+  assert.equal("bcedf", sendPayload.token);
+  assert.equal("124", sendPayload.job);
+});
+
+test('stopWatching will send remove command', function (assert) {
+  var sendPayload = null;
+  let service = this.subject({
+    'websockets': {
+      'socketFor': socketFor
+    }
+  });
+
+  function socketFor() {
+    return {
+      on() {
+      },
+      off() {
+      },
+      send(payload) {
+        sendPayload = JSON.parse(payload);
+      }
+    };
+  }
+
+  assert.ok(service);
+  service.startWatching('abcdef', '123');
+  service.stopWatching('abcdef', '123');
+  assert.equal("remove", sendPayload.command);
+  assert.equal("abcdef", sendPayload.token);
+  assert.equal("123", sendPayload.job);
+});
+
+
+test('onMessage will reload job for normal update', function (assert) {
+  var fakeJob = {
+    reload() {
+      fakeJob.reloaded = true;
+    }
+  };
+  let service = this.subject({
+    'store': {
+      findRecord() {
+        return {
+          'then': function (func) {
+            func(fakeJob);
+          }
+        };
+      }
+    }
+  });
+  var payload = {
+    'data': JSON.stringify({
+      'status': 'ok',
+      'data': {
+        "job": "1",
+        "state": "R",
+        "step": "V"
+      }
+    })
+  };
+  service.onMessage(payload);
+  assert.equal(true, fakeJob.reloaded);
+});
+
+
+test('onMessage with websocket error will be handled', function (assert) {
+  let service = this.subject();
+  assert.ok(service);
+  var payload = {
+    'data': JSON.stringify({
+      'status': 'error',
+      'data': {
+        'message': 'bad'
+      }
+    })
+  };
+  service.onMessage(payload);
+});


### PR DESCRIPTION
This service updates the jobs in the store when a message comes in.
This is only used on the job-details screen but could be used elsewhere.

Also adds jobErrors to job model simplifying updates to this model.
Requires https://github.com/Duke-GCB/bespin-api/pull/31.