### PR TITLE
Upgrade travis to nodejs 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '4'
+- '6'
 cache:
   directories:
   - node_modules


### PR DESCRIPTION
After merging the latest branch travis started failing:
```
$ npm test
> bespin-ui@0.0.0 test /home/travis/build/Duke-GCB/bespin-ui
> ember test
Could not start watchman; falling back to NodeWatcher for file system events.
Visit http://ember-cli.com/user-guide/#watchman for more info.
Building
Cannot find module 'babel-plugin-transform-es2015-block-scoping'
Error: Cannot find module 'babel-plugin-transform-es2015-block-scoping'
```
Building locally with nodejs 7 I didn't encounter this error.
Running locally 'babel-preset-env@1.5.2' pulled in 'babel-plugin-transform-es2015-block-scoping'. From what I can tell travis didn't install this as part of  'babel-preset-env@1.5.2.

nodejs 6 is the current LTS version.

