### PR TITLE
Allow user to enter a job name

### DIFF
--- a/app/components/questionnaire/job-name.js
+++ b/app/components/questionnaire/job-name.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 
 const JobName = Ember.Component.extend({
-  tagName: 'div',
 });
 
 JobName.reopenClass({

--- a/app/components/questionnaire/job-name.js
+++ b/app/components/questionnaire/job-name.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+const JobName = Ember.Component.extend({
+  tagName: 'div',
+});
+
+JobName.reopenClass({
+  positionalParams: ['answerSet']
+});
+
+export default JobName;

--- a/app/routes/jobs/new/build-answer-set.js
+++ b/app/routes/jobs/new/build-answer-set.js
@@ -10,7 +10,6 @@ export default Ember.Route.extend({
     };
     return Ember.RSVP.hash(promises).then(hash => {
       return store.createRecord('job-answer-set', {
-        jobName: '',
         questionnaire: hash.questionnaire,
         stageGroup: hash.stageGroup
       });

--- a/app/routes/jobs/new/build-answer-set.js
+++ b/app/routes/jobs/new/build-answer-set.js
@@ -10,7 +10,7 @@ export default Ember.Route.extend({
     };
     return Ember.RSVP.hash(promises).then(hash => {
       return store.createRecord('job-answer-set', {
-        jobName: 'FIXME',
+        jobName: '',
         questionnaire: hash.questionnaire,
         stageGroup: hash.stageGroup
       });

--- a/app/templates/components/questionnaire/answer-form.hbs
+++ b/app/templates/components/questionnaire/answer-form.hbs
@@ -1,3 +1,6 @@
 {{questionnaire/answer-form-header answerSet.questionnaire}}
+
+{{questionnaire/job-name answerSet}}
+
 {{questionnaire/answer-form-list answerSet}}
 {{yield}}

--- a/app/templates/components/questionnaire/job-name.hbs
+++ b/app/templates/components/questionnaire/job-name.hbs
@@ -1,7 +1,3 @@
-<div class="row">
-    <div class="col-md-6">
-        <label for="jobName">Job Name:</label>
-        {{input class='form-control' id='jobName' placeholder='Enter name for this job' value=answerSet.jobName}}
-    </div>
-</div>
+<label for="jobName">Job Name:</label>
+{{input class='form-control' id='jobName' placeholder='Enter name for this job' value=answerSet.jobName}}
 {{yield}}

--- a/app/templates/components/questionnaire/job-name.hbs
+++ b/app/templates/components/questionnaire/job-name.hbs
@@ -1,0 +1,7 @@
+<div class="row">
+    <div class="col-md-6">
+        <label for="jobName">Job Name:</label>
+        {{input class='form-control' id='jobName' placeholder='Enter name for this job' value=answerSet.jobName}}
+    </div>
+</div>
+{{yield}}

--- a/tests/integration/components/questionnaire/answer-form-test.js
+++ b/tests/integration/components/questionnaire/answer-form-test.js
@@ -11,5 +11,5 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{questionnaire/answer-form}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(this.$().text().trim(), 'Job Name:');
 });

--- a/tests/integration/components/questionnaire/job-name-test.js
+++ b/tests/integration/components/questionnaire/job-name-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('questionnaire/job-name', 'Integration | Component | questionnaire/job name', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{questionnaire/job-name}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#questionnaire/job-name}}
+      template block text
+    {{/questionnaire/job-name}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/questionnaire/job-name-test.js
+++ b/tests/integration/components/questionnaire/job-name-test.js
@@ -1,17 +1,17 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
 
 moduleForComponent('questionnaire/job-name', 'Integration | Component | questionnaire/job name', {
   integration: true
 });
 
-test('it renders', function(assert) {
-
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
-
-  this.render(hbs`{{questionnaire/job-name}}`);
-
-  assert.equal(this.$().text().trim(), 'Job Name:');
-
+test('it renders a job name', function(assert) {
+  let answerSet = Ember.Object.create({
+    jobName: 'test'
+  });
+  this.set('answerSet', answerSet);
+  this.render(hbs`{{questionnaire/job-name answerSet}}`);
+  assert.equal(this.$('label').text(), 'Job Name:');
+  assert.equal(this.$('#jobName').val(), 'test');
 });

--- a/tests/integration/components/questionnaire/job-name-test.js
+++ b/tests/integration/components/questionnaire/job-name-test.js
@@ -12,14 +12,6 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{questionnaire/job-name}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(this.$().text().trim(), 'Job Name:');
 
-  // Template block usage:
-  this.render(hbs`
-    {{#questionnaire/job-name}}
-      template block text
-    {{/questionnaire/job-name}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
 });


### PR DESCRIPTION
Removes "FIXME" hard coded value and user can how enter the job name.
Screen shot:
<img width="819" alt="screen shot 2017-06-27 at 9 55 26 am" src="https://user-images.githubusercontent.com/1024463/27592825-73104606-5b23-11e7-96b8-52b64abf9f68.png">

__Known Issues__
- The paired file picker looks like it blends in with this control.
- Leaving the `Job Name` field blank results in an unhandled 400 error `{"job-answer-sets":{"job_name":["This field may not be blank."]}}`
