### PR TITLE
Cleans up answer form components and CSS

### DIFF
--- a/app/components/questionnaire/answer-form-header.js
+++ b/app/components/questionnaire/answer-form-header.js
@@ -1,5 +1,13 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
-  tagName: 'h2'
+const AnswerFormHeader = Ember.Component.extend({
+  tagName: 'h2',
+  questionnaire: null,
+  title: Ember.computed.alias('questionnaire.name')
 });
+
+AnswerFormHeader.reopenClass({
+  positionalParams: ['questionnaire']
+});
+
+export default AnswerFormHeader;

--- a/app/components/questionnaire/answer-form-header.js
+++ b/app/components/questionnaire/answer-form-header.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
 
 const AnswerFormHeader = Ember.Component.extend({
-  tagName: 'h2',
+  classNames: ['row'],
   questionnaire: null,
-  title: Ember.computed.alias('questionnaire.name')
+  title: Ember.computed.alias('questionnaire.name'),
+  subtitle: Ember.computed.alias('questionnaire.description')
 });
 
 AnswerFormHeader.reopenClass({

--- a/app/components/questionnaire/answer-form-list.js
+++ b/app/components/questionnaire/answer-form-list.js
@@ -12,7 +12,6 @@ const ComponentInfos = [
 ];
 
 const AnswerFormList = Ember.Component.extend({
-  tagName: 'ul',
   classNames: ['answer-form-list'],
   answerSet: null,
   fields: Ember.computed('answerSet.questionnaire.userFieldsJson.@each', function() {

--- a/app/components/questionnaire/answer-form.js
+++ b/app/components/questionnaire/answer-form.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 const AnswerForm = Ember.Component.extend({
+  classNames: ['container']
 });
 
 AnswerForm.reopenClass({

--- a/app/components/questionnaire/empty-selection.js
+++ b/app/components/questionnaire/empty-selection.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: ['empty-selection', 'well', 'well-sm']
+});

--- a/app/components/questionnaire/file-group-list.js
+++ b/app/components/questionnaire/file-group-list.js
@@ -12,8 +12,8 @@ const FileGroupList = Ember.Component.extend({
   /**
    * Encapsulates a file picker and a grouping/pairing control
    */
-  tagName: 'li',
-  classNames: ['file-group-list'],
+  tagName: 'div',
+  classNames: ['file-group-list', 'row'],
   fileKindName: DEFAULT_FILE_KIND_NAME, // What kind of file are we picking?
   groupSize: DEFAULT_GROUP_SIZE,
   groupSizeName: Ember.computed('groupSize', function() {

--- a/app/components/questionnaire/job-name.js
+++ b/app/components/questionnaire/job-name.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 const JobName = Ember.Component.extend({
-  classNames: ['row']
+  classNames: ['row', 'job-name']
 });
 
 JobName.reopenClass({

--- a/app/components/questionnaire/job-name.js
+++ b/app/components/questionnaire/job-name.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 const JobName = Ember.Component.extend({
+  classNames: ['row']
 });
 
 JobName.reopenClass({

--- a/app/controllers/jobs/new/build-answer-set.js
+++ b/app/controllers/jobs/new/build-answer-set.js
@@ -2,6 +2,10 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   actions: {
+    back() {
+      let workflowVersionId = this.get('model.questionnaire.workflowVersion.id');
+      this.transitionToRoute('jobs.new.select-questionnaire', workflowVersionId);
+    },
     saveAndCreateJob() {
       // Must save all the things that compose an answer set
       let answerSet = this.get('model');

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -52,11 +52,3 @@ span.is-disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
-
-.answer-form-list li {
-  list-style: none;
-}
-
-.file-group-row li {
-  list-style: none;
-}

--- a/app/templates/components/questionnaire/answer-form-header.hbs
+++ b/app/templates/components/questionnaire/answer-form-header.hbs
@@ -1,2 +1,3 @@
-{{ title }}
+<h2>{{ title }}</h2>
+<h4>{{ subtitle }}</h4>
 {{yield}}

--- a/app/templates/components/questionnaire/answer-form.hbs
+++ b/app/templates/components/questionnaire/answer-form.hbs
@@ -1,6 +1,4 @@
 {{questionnaire/answer-form-header answerSet.questionnaire}}
-
 {{questionnaire/job-name answerSet}}
-
 {{questionnaire/answer-form-list answerSet}}
 {{yield}}

--- a/app/templates/components/questionnaire/empty-selection.hbs
+++ b/app/templates/components/questionnaire/empty-selection.hbs
@@ -1,0 +1,2 @@
+None selected
+{{yield}}

--- a/app/templates/components/questionnaire/file-group-list.hbs
+++ b/app/templates/components/questionnaire/file-group-list.hbs
@@ -1,9 +1,9 @@
 <div class="col-md-6 file-group-list-picker">
-  <h5>Pick your {{ fileKindName }} {{ groupSizeName }} from Duke Data Service</h5>
+  <label>Pick your {{ fileKindName }} {{ groupSizeName }} from Duke Data Service</label>
   {{dds.dds-project-files-picker projects selectedDdsFiles (action 'addFile')}}
 </div>
 <div class="col-md-6 file-group-list-selections">
-  <h5>Selected {{ fileKindName }} {{ groupSizeName }}</h5>
+  <label>Selected {{ fileKindName }} {{ groupSizeName }}</label>
   {{#each groups as |group groupIndex|}}
     {{questionnaire/file-group-row group groupIndex (action 'removeAt')}}
   {{/each}}

--- a/app/templates/components/questionnaire/file-group-list.hbs
+++ b/app/templates/components/questionnaire/file-group-list.hbs
@@ -1,14 +1,11 @@
-<!-- component to pick an array of file groups -->
-<div class="row">
-  <div class="col-md-6 file-group-list-picker">
-    <h5>Pick your {{ fileKindName }} {{ groupSizeName }} from Duke Data Service</h5>
-    {{dds.dds-project-files-picker projects selectedDdsFiles (action 'addFile')}}
-  </div>
-  <div class="col-md-6 file-group-list-selections">
-    <h5>Selected {{ fileKindName }} {{ groupSizeName }}</h5>
-    {{#each groups as |group groupIndex|}}
-      {{questionnaire/file-group-row group groupIndex (action 'removeAt')}}
-    {{/each}}
-  </div>
+<div class="col-md-6 file-group-list-picker">
+  <h5>Pick your {{ fileKindName }} {{ groupSizeName }} from Duke Data Service</h5>
+  {{dds.dds-project-files-picker projects selectedDdsFiles (action 'addFile')}}
+</div>
+<div class="col-md-6 file-group-list-selections">
+  <h5>Selected {{ fileKindName }} {{ groupSizeName }}</h5>
+  {{#each groups as |group groupIndex|}}
+    {{questionnaire/file-group-row group groupIndex (action 'removeAt')}}
+  {{/each}}
 </div>
 {{yield}}

--- a/app/templates/components/questionnaire/file-group-list.hbs
+++ b/app/templates/components/questionnaire/file-group-list.hbs
@@ -6,6 +6,8 @@
   <label>Selected {{ fileKindName }} {{ groupSizeName }}</label>
   {{#each groups as |group groupIndex|}}
     {{questionnaire/file-group-row group groupIndex (action 'removeAt')}}
+  {{else}}
+    {{questionnaire/empty-selection}}
   {{/each}}
 </div>
 {{yield}}

--- a/app/templates/components/questionnaire/job-name.hbs
+++ b/app/templates/components/questionnaire/job-name.hbs
@@ -1,3 +1,9 @@
-<label for="jobName">Job Name:</label>
-{{input class='form-control' id='jobName' placeholder='Enter name for this job' value=answerSet.jobName}}
+<div class="col-md-12">
+  {{#bs-form as |form|}}
+    {{#form.group class='job-name-group'}}
+      <label for="{{concat elementId '-jobName'}}">Job Name:</label>
+      {{input class='form-control job-name-input' id=(concat elementId '-jobName') placeholder='Enter name for this job' value=answerSet.jobName}}
+    {{/form.group}}
+  {{/bs-form}}
+</div>
 {{yield}}

--- a/app/templates/jobs/new/build-answer-set.hbs
+++ b/app/templates/jobs/new/build-answer-set.hbs
@@ -1,5 +1,7 @@
 {{questionnaire/answer-form model}}
-{{#bs-button type="default" onClick=(action 'saveAndCreateJob') class="save-button"}}Save{{/bs-button}}
+
+{{#bs-button type="default" onClick=(action 'back') class="back-button"}}Back{{/bs-button}}
+{{#bs-button type="primary" onClick=(action 'saveAndCreateJob') class="pull-right next-button"}}Save{{/bs-button}}
 
 {{! move this to another component }}
 {{#if model.errors}}

--- a/tests/integration/components/questionnaire/answer-form-header-test.js
+++ b/tests/integration/components/questionnaire/answer-form-header-test.js
@@ -6,7 +6,9 @@ moduleForComponent('questionnaire/answer-form-header', 'Integration | Component 
 });
 
 test('it renders', function(assert) {
-  this.render(hbs`{{questionnaire/answer-form-header title='Header Title'}}`);
+  this.set('questionnaire', {name: 'Header Title', description: 'Header Subtitle'});
+  this.render(hbs`{{questionnaire/answer-form-header questionnaire}}`);
 
-  assert.equal(this.$().text().trim(), 'Header Title');
+  assert.equal(this.$('h2').text().trim(), 'Header Title');
+  assert.equal(this.$('h4').text().trim(), 'Header Subtitle');
 });

--- a/tests/integration/components/questionnaire/empty-selection-test.js
+++ b/tests/integration/components/questionnaire/empty-selection-test.js
@@ -1,0 +1,11 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('questionnaire/empty-selection', 'Integration | Component | questionnaire/empty selection', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  this.render(hbs`{{questionnaire/empty-selection}}`);
+  assert.equal(this.$().text().trim(), 'None selected');
+});

--- a/tests/integration/components/questionnaire/file-group-list-test.js
+++ b/tests/integration/components/questionnaire/file-group-list-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import StoreStub from '../../../helpers/store-stub';
+import Ember from 'ember';
 
 moduleForComponent('questionnaire/file-group-list', 'Integration | Component | questionnaire/file group list', {
   integration: true,
@@ -20,3 +21,20 @@ test('it renders', function(assert) {
   assert.equal(this.$('.file-group-list-selections label').text().trim(), 'Selected read pairs');
 });
 
+test('it toggles empty selection', function(assert) {
+  Ember.run(() => {
+    this.set('fileItems', Ember.Object.create({
+      fileItemGroups: []
+    }));
+    this.render(hbs`{{questionnaire/file-group-list fileItems=fileItems}}`);
+
+    assert.equal(this.$('.empty-selection').length, 1, 'with no groups, should show the empty-selection component');
+    this.set('fileItems.fileItemGroups', [
+      [
+        {ddsFile: 'foo'},
+      ]
+    ]);
+    this.render(hbs`{{questionnaire/file-group-list fileItems=fileItems}}`);
+    assert.equal(this.$('.empty-selection').length, 0, 'with groups, should hide the empty-selection component');
+  });
+});

--- a/tests/integration/components/questionnaire/file-group-list-test.js
+++ b/tests/integration/components/questionnaire/file-group-list-test.js
@@ -16,7 +16,7 @@ moduleForComponent('questionnaire/file-group-list', 'Integration | Component | q
 
 test('it renders', function(assert) {
   this.render(hbs`{{questionnaire/file-group-list}}`);
-  assert.equal(this.$('.file-group-list-picker h5').text().trim(), 'Pick your read pairs from Duke Data Service');
-  assert.equal(this.$('.file-group-list-selections h5').text().trim(), 'Selected read pairs');
+  assert.equal(this.$('.file-group-list-picker label').text().trim(), 'Pick your read pairs from Duke Data Service');
+  assert.equal(this.$('.file-group-list-selections label').text().trim(), 'Selected read pairs');
 });
 

--- a/tests/integration/components/questionnaire/job-name-test.js
+++ b/tests/integration/components/questionnaire/job-name-test.js
@@ -13,5 +13,5 @@ test('it renders a job name', function(assert) {
   this.set('answerSet', answerSet);
   this.render(hbs`{{questionnaire/job-name answerSet}}`);
   assert.equal(this.$('label').text(), 'Job Name:');
-  assert.equal(this.$('#jobName').val(), 'test');
+  assert.equal(this.$('.job-name-input').val(), 'test');
 });

--- a/tests/unit/controllers/jobs/new/build-answer-set-test.js
+++ b/tests/unit/controllers/jobs/new/build-answer-set-test.js
@@ -10,6 +10,23 @@ test('it exists', function(assert) {
   assert.ok(controller);
 });
 
+test('it handles back action', function(assert) {
+  let controller = this.subject({
+    model: Ember.Object.create({
+      questionnaire: {
+        workflowVersion: {
+          id: 7
+        }
+      }
+  }),
+    transitionToRoute(routeName, workflowVersionId) {
+      assert.equal(routeName, 'jobs.new.select-questionnaire','back action should transition to select-questionnaire');
+      assert.equal(workflowVersionId, 7, 'back actoun should preserve workflow version');
+    }
+  });
+  controller.send('back');
+});
+
 test('it creates job and transitions to show route', function(assert) {
   assert.expect(3);
   let done = assert.async();


### PR DESCRIPTION
- Makes layout consistent, removing ul/li in answer-form-list and applying form-group to job name
- Uses labels instead of h5 in answer component
- Adds back button to the build-answer-set route
- Displays 'None selected' when no files are picked

Fixes #30