### PR TITLE
Sort projects and files by name when selecting

### DIFF
--- a/app/components/dds/dds-file-picker.js
+++ b/app/components/dds/dds-file-picker.js
@@ -17,7 +17,7 @@ const DDSFilePicker = Ember.Component.extend({
     this.get('store').query('dds-resource', {
       project_id: this.get('project.id')
     }).then((resources) => {
-      this.set('resources', resources);
+      this.set('resources', resources.sortBy('name'));
     });
   }))
 });

--- a/app/components/dds/dds-resource-tree.js
+++ b/app/components/dds/dds-resource-tree.js
@@ -19,7 +19,7 @@ const DDSResourceTree = Ember.Component.extend({
     this.get('store').query('dds-resource', {
       folder_id: this.get('resource.id')
     }).then((children) => {
-      this.set('children', children);
+      this.set('children', children.sortBy('name'));
       this.set('fetchedOnce', true);
     });
   },

--- a/app/components/questionnaire/file-group-list.js
+++ b/app/components/questionnaire/file-group-list.js
@@ -22,7 +22,8 @@ const FileGroupList = Ember.Component.extend({
   fieldName: null,
   ddsProjects: Ember.inject.service(),
   ddsUserCredentials: Ember.inject.service(),
-  projects: Ember.computed.alias('ddsProjects.projects'),
+  credential: null, // populated on didInsertElement
+  projects: null, // populated on didInsertElement
   fileItems: null,
   selectedDdsFiles: Ember.computed.alias('fileItems.ddsFiles'),
   groups: Ember.computed.map('fileItems.fileItemGroups', function(fileItemGroup) {
@@ -37,7 +38,7 @@ const FileGroupList = Ember.Component.extend({
   inputFiles: Ember.computed.alias('fileItems.inputFiles.[]'),
   actions: {
     addFile(file) {
-      const credential = this.get('ddsUserCredentials.primaryCredential');
+      const credential = this.get('credential');
       const prefix = `${this.get('fieldName')}_${Date.now()}`;
       const fileItem = FileItem.create({ddsFile: file, prefix: prefix, credential: credential});
       this.get('fileItems').addFileItem(fileItem);
@@ -48,14 +49,25 @@ const FileGroupList = Ember.Component.extend({
       this.sendAction('answerChanged', this);
     }
   },
-  init(){
+
+  init() {
     this._super(...arguments);
-    // Force a load of the credentials service. This is a hack!
-    this.get('ddsUserCredentials');
     if(Ember.isEmpty(this.get('fileItems'))) {
       this.set('fileItems', FileItemList.create());
     }
+  },
+
+  // Per https://emberigniter.com/render-promise-before-it-resolves/
+  didInsertElement() {
+    this._super(...arguments);
+    this.get('ddsUserCredentials').primaryCredential().then(credential => {
+      this.set('credential', credential);
+    });
+    this.get('ddsProjects').projects().then(projects => {
+      this.set('projects', projects);
+    });
   }
+
 });
 
 FileGroupList.reopenClass({

--- a/app/components/questionnaire/file-group-list.js
+++ b/app/components/questionnaire/file-group-list.js
@@ -67,7 +67,6 @@ const FileGroupList = Ember.Component.extend({
       this.set('projects', projects);
     });
   }
-
 });
 
 FileGroupList.reopenClass({

--- a/app/services/dds-projects.js
+++ b/app/services/dds-projects.js
@@ -2,11 +2,9 @@ import Ember from 'ember';
 
 export default Ember.Service.extend({
   store: Ember.inject.service(),
-  projects: null,
-  init() {
-    this._super(...arguments);
-    this.get('store').findAll('dds-project').then(projects => {
-      this.set('projects', projects);
+  projects() {
+    return this.get('store').findAll('dds-project').then(projects => {
+      return Ember.RSVP.resolve(projects.sortBy('name'));
     });
   }
 });

--- a/app/services/dds-user-credentials.js
+++ b/app/services/dds-user-credentials.js
@@ -9,11 +9,9 @@ import Ember from 'ember';
 
 export default Ember.Service.extend({
   store: Ember.inject.service(),
-  primaryCredential: null,
-  init() {
-    this._super(...arguments);
-    this.get('store').findAll('dds-user-credential').then(credentials => {
-      this.set('primaryCredential', credentials.get('firstObject'));
+  primaryCredential() {
+    return this.get('store').findAll('dds-user-credential').then(credentials => {
+      return Ember.RSVP.resolve(credentials.get('firstObject'));
     });
   }
 });

--- a/tests/unit/components/dds/dds-file-picker-test.js
+++ b/tests/unit/components/dds/dds-file-picker-test.js
@@ -13,11 +13,8 @@ const StoreStub = Ember.Service.extend({
 });
 
 moduleForComponent('dds/dds-file-picker', 'Unit | Component | dds/dds file picker', {
-  // Specify the other units that are required for this test
-  // needs: ['component:foo', 'helper:bar'],
   unit: true,
   beforeEach() {
-    // inject the service
     this.register('service:store', StoreStub);
   }
 });

--- a/tests/unit/components/dds/dds-file-picker-test.js
+++ b/tests/unit/components/dds/dds-file-picker-test.js
@@ -1,0 +1,34 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
+
+const StoreStub = Ember.Service.extend({
+  query() {
+    return Ember.RSVP.resolve([
+      Ember.Object.create({id: 1, name: 'C'}),
+      Ember.Object.create({id: 2, name: 'B'}),
+      Ember.Object.create({id: 3, name: 'D'}),
+      Ember.Object.create({id: 4, name: 'A'}),
+    ]);
+  }
+});
+
+moduleForComponent('dds/dds-file-picker', 'Unit | Component | dds/dds file picker', {
+  // Specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar'],
+  unit: true,
+  beforeEach() {
+    // inject the service
+    this.register('service:store', StoreStub);
+  }
+});
+
+test('it sorts files by name', function(assert) {
+  let component = this.subject();
+  // Run in two separate Ember.run blocks, since resources are fetched as a side effect of setting project
+  Ember.run(() => {
+    component.set('project', Ember.Object.create({id:7}));
+  });
+  Ember.run(() => {
+    assert.deepEqual(component.get('resources').mapBy('name'), ['A', 'B', 'C', 'D']);
+  });
+});

--- a/tests/unit/components/dds/dds-resource-tree-test.js
+++ b/tests/unit/components/dds/dds-resource-tree-test.js
@@ -1,0 +1,32 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
+
+const StoreStub = Ember.Service.extend({
+  query() {
+    return Ember.RSVP.resolve([
+      Ember.Object.create({id: 1, name: 'C'}),
+      Ember.Object.create({id: 2, name: 'D'}),
+      Ember.Object.create({id: 3, name: 'B'}),
+      Ember.Object.create({id: 4, name: 'A'}),
+    ]);
+  }
+});
+
+moduleForComponent('dds/dds-resource-tree', 'Unit | Component | dds/dds resource tree', {
+  unit: true,
+  beforeEach() {
+    this.register('service:store', StoreStub);
+  }
+});
+
+test('it sorts files by name', function(assert) {
+  let component = this.subject({resource: Ember.Object.create()});
+  // Run in two separate Ember.run blocks, since side effect of fetchChildren must complete before we can check children
+  Ember.run(() => {
+    component.fetchChildren()
+  });
+  Ember.run(() => {
+    assert.deepEqual(component.get('children').mapBy('name'), ['A', 'B', 'C', 'D']);
+    assert.ok(component.get('fetchedOnce'));
+  });
+});

--- a/tests/unit/components/questionnaire/file-group-list-test.js
+++ b/tests/unit/components/questionnaire/file-group-list-test.js
@@ -24,7 +24,6 @@ test('it renders', function(assert) {
 
 test('it computes answer with field name and files', function (assert) {
   const fieldName = 'mock_files';
-
   const mockFileItems = Ember.Object.create({
     cwlObjectValue: [2,3,1]
   });
@@ -82,9 +81,7 @@ test('it handles addFile action', function (assert) {
     groupSize:4,
     fieldName: 'myField',
     fileItems: mockFileItems,
-    ddsUserCredentials: Ember.Object.create({
-      primaryCredential: 'myCredential'
-    })
+    credential: 'myCredential'
   });
   fileGroupList.send('addFile', mockDdsFile);
 });

--- a/tests/unit/services/dds-projects-test.js
+++ b/tests/unit/services/dds-projects-test.js
@@ -1,11 +1,23 @@
 import { moduleFor, test } from 'ember-qunit';
 import StoreStub from '../../helpers/store-stub';
+import Ember from 'ember';
+
+const ProjectsStoreStub = StoreStub.extend({
+  findAllFunction() {
+    return [
+      Ember.Object.create({id: 1, name: 'C'}),
+      Ember.Object.create({id: 2, name: 'A'}),
+      Ember.Object.create({id: 3, name: 'D'}),
+      Ember.Object.create({id: 4, name: 'B'})
+    ];
+  }
+});
 
 moduleFor('service:dds-projects', 'Unit | Service | dds projects', {
   // Specify the other units that are required for this test.
   needs: ['model:dds-project'],
   beforeEach() {
-    this.register('service:store', StoreStub);
+    this.register('service:store', ProjectsStoreStub);
     this.inject.service('store', {as: 'store'});
   }
 });
@@ -16,4 +28,16 @@ test('it exists', function(assert) {
   assert.ok(service);
 });
 
-// Todo: Test the promise resolving, but the service doesn't report when that happens
+test('it fetches projects', function(assert) {
+  let service = this.subject();
+  service.projects().then(projects => {
+    assert.equal(projects.length, 4);
+  });
+});
+
+test('it sorts projects by name', function(assert) {
+  let service = this.subject();
+  service.projects().then(projects => {
+    assert.deepEqual(projects.mapBy('name'), ['A','B','C','D']);
+  });
+});


### PR DESCRIPTION
- Reworks services (dds-projects, dds-user-credentials) that were using hacks to populate their arrays to use promises instead
- Sorts projects in the dds-projects service and files in the dds-file-picker and dds-resource-tree
