### PR TITLE
Disables prefixing of staged file names

### DIFF
--- a/app/components/questionnaire/file-group-list.js
+++ b/app/components/questionnaire/file-group-list.js
@@ -39,7 +39,9 @@ const FileGroupList = Ember.Component.extend({
   actions: {
     addFile(file) {
       const credential = this.get('credential');
-      const prefix = `${this.get('fieldName')}_${Date.now()}`;
+      // Temporarily removing prefix to preserve original file names.
+      // See https://github.com/Duke-GCB/bespin-ui/issues/39
+      const prefix = ''; // `${this.get('fieldName')}_${Date.now()}_`;
       const fileItem = FileItem.create({ddsFile: file, prefix: prefix, credential: credential});
       this.get('fileItems').addFileItem(fileItem);
       this.sendAction('answerChanged', this);

--- a/app/models/dds-resource.js
+++ b/app/models/dds-resource.js
@@ -17,7 +17,7 @@ export default DS.Model.extend({
   version_id: DS.attr('string'),
 
   getNameWithPrefix(prefix) {
-    return `${prefix}_${this.get('name')}`;
+    return `${prefix}${this.get('name')}`;
   },
 
   cwlFileObject(prefix) {

--- a/tests/unit/components/questionnaire/file-group-list-test.js
+++ b/tests/unit/components/questionnaire/file-group-list-test.js
@@ -64,11 +64,17 @@ test('it handles addFile action', function (assert) {
   assert.expect(4);
   const mockDdsFile = Ember.Object.create({
     createJobInputFile(prefix, credential) {
-      assert.equal(prefix.indexOf('myField'), 0);
+      // Temporarily removing prefix to preserve original file names.
+      // See https://github.com/Duke-GCB/bespin-ui/issues/39
+      // assert.equal(prefix.indexOf('myField'), 0);
+      assert.equal(prefix,'');
       assert.equal(credential, 'myCredential');
     },
     cwlFileObject(prefix) {
-      assert.equal(prefix.indexOf('myField'), 0);
+      // Temporarily removing prefix to preserve original file names.
+      // See https://github.com/Duke-GCB/bespin-ui/issues/39
+      // assert.equal(prefix.indexOf('myField'), 0);
+      assert.equal(prefix, '');
     }
   });
 

--- a/tests/unit/models/dds-resource-test.js
+++ b/tests/unit/models/dds-resource-test.js
@@ -3,7 +3,7 @@ import { testRelationship } from '../../helpers/test-relationships';
 import Ember from 'ember';
 
 moduleForModel('dds-resource', 'Unit | Model | dds resource', {
-  needs: ['model:dds-project', 'model:dds-job-input-file', 'model:dds-user-credential']
+  needs: ['model:dds-project', 'model:dds-job-input-file', 'model:dds-user-credential', 'model:job-file-stage-group']
 });
 
 test('it exists', function(assert) {
@@ -32,14 +32,14 @@ test('it generates prefixed file names', function(assert) {
   let model = this.subject();
   Ember.run(() => {
     model.set('name', 'myfile.txt');
-    let prefixed = model.getNameWithPrefix('prefix');
+    let prefixed = model.getNameWithPrefix('prefix_');
     assert.equal(prefixed, 'prefix_myfile.txt');
   });
 });
 
 test('it generates a CWL File object', function(assert) {
   const ddsFile = this.subject({name: 'myfile.txt'});
-  const prefix = 'prefix';
+  const prefix = 'prefix_';
   const cwlFile = ddsFile.cwlFileObject(prefix);
   assert.ok(cwlFile);
   const expected = {
@@ -57,7 +57,7 @@ test('It works with map', function (assert) {
       this.store().createRecord('dds-resource', {name: 'file3.txt'})
     ];
     const wrapped = files.map((file, index) => {
-      return file.cwlFileObject(index);
+      return file.cwlFileObject(`${index}_`);
     });
     const expected = [
       {
@@ -88,7 +88,7 @@ test('It creates job input files with DDS IDs', function (assert) {
       project: project,
       id: fileId,
     });
-    const prefix = 'input1';
+    const prefix = 'input1_';
     const inputFile = ddsFile.createJobInputFile(prefix, cred);
 
     assert.equal(inputFile.get('destinationPath'), 'input1_file1.txt');


### PR DESCRIPTION
- Current candidate workflow relies on parsing  file names, so we'll avoid altering them for now
- However, leaving the original file names means that conflicts would result in overwriting one in the worker VM
- Removes explicit '_' from prefix function to allow this
- file-group-list changes can be revisited later to ensure uniqueness

Fixes #39