### PR TITLE
Disables prefixing of staged file names

### DIFF
--- a/app/models/job.js
+++ b/app/models/job.js
@@ -22,6 +22,9 @@ export default DS.Model.extend({
   isFinished: Ember.computed('state', function() {
     return this.get('state') === 'F';
   }),
+  isErrored:  Ember.computed('state', function() {
+    return this.get('state') === 'E';
+  }),
   outputDir: DS.belongsTo('job-output-dir'),
   // Named jobErrors because DS.Model already has an errors property (contains validation error messages)
   jobErrors: DS.hasMany('job-error'),

--- a/app/templates/components/job-detail.hbs
+++ b/app/templates/components/job-detail.hbs
@@ -19,7 +19,7 @@
             <dt>Results</dt>
             <dd class="job-results"><a class="job-results-link" href="{{output-dir-link job.outputDir}}">{{job.outputDir.project.name}}/{{job.outputDir.dirName}}</a></dd>
           {{/if}}
-          {{#if job.jobErrors}}
+          {{#if job.isErrored}}
               <dt>Errors</dt>
               {{#each job.jobErrors as |jobError|}}
                   <dd class="job-error"><pre>{{jobError.content}}</pre></dd>

--- a/tests/integration/components/job-detail-test.js
+++ b/tests/integration/components/job-detail-test.js
@@ -68,11 +68,18 @@ test('it pretty-prints JSON', function(assert) {
   assert.equal(this.$('.job-order pre').text(), prettified_indent4);
 });
 
-test('it shows errors', function (assert) {
+test('it shows errors when job isErrored', function (assert) {
+  this.set('job.isErrored', true);
   this.render(hbs`{{job-detail job}}`);
   assert.equal(this.$('.job-error').length, 2);
   assert.equal(this.$('.job-error:eq(0)').text(), 'Error 1');
   assert.equal(this.$('.job-error:eq(1)').text(), 'Error 2');
+});
+
+test('it hides errors when not isErrored', function(assert) {
+  this.set('job.isErrored', false);
+  this.render(hbs`{{job-detail job}}`);
+  assert.equal(this.$('.job-error').length, 0);
 });
 
 test('it does not render results unless finished', function(assert) {

--- a/tests/unit/models/job-test.js
+++ b/tests/unit/models/job-test.js
@@ -38,6 +38,16 @@ test('it computes isNew', function(assert) {
   });
 });
 
+test('it computes isErrored', function(assert) {
+  let job = this.subject();
+  Ember.run(() => {
+    job.set('state', 'N');
+    assert.notOk(job.get('isErrored'));
+    job.set('state', 'E');
+    assert.ok(job.get('isErrored'));
+  });
+});
+
 testRelationship('job', {key: 'workflowVersion', kind: 'belongsTo', type: 'workflow-version'});
 testRelationship('job', {key: 'outputDir', kind: 'belongsTo', type: 'job-output-dir'});
 testRelationship('job', {key: 'stageGroup', kind: 'belongsTo', type: 'job-file-stage-group'});


### PR DESCRIPTION
- Current candidate workflow relies on parsing  file names, so we'll avoid altering them for now
- However, leaving the original file names means that conflicts would result in overwriting one in the worker VM
- Removes explicit '_' from prefix function to allow this
- file-group-list changes can be revisited later to ensure uniqueness

Fixes #39