### PR TITLE
Add all button

### DIFF
--- a/app/components/dds/dds-add-button.js
+++ b/app/components/dds/dds-add-button.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 const DDSAddButton = Ember.Component.extend({
   resource: null,
   tagName: 'span',
-  classNames: ['glyphicon','dds-add-button', 'glyphicon-file'],
+  classNames: ['glyphicon','dds-add-button', 'glyphicon-file', 'dds-button'],
   click() {
     this.sendAction();
   }

--- a/app/components/dds/dds-expand-button.js
+++ b/app/components/dds/dds-expand-button.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 const DDSExpandButton = Ember.Component.extend({
   expanded: false,
   tagName: 'span',
-  classNames: ['glyphicon','dds-expand-button'],
+  classNames: ['glyphicon','dds-expand-button','dds-button'],
   classNameBindings: ['expanded:glyphicon-folder-open:glyphicon-folder-close'],
   click() {
     this.sendAction();

--- a/app/components/dds/dds-file-picker.js
+++ b/app/components/dds/dds-file-picker.js
@@ -16,6 +16,13 @@ const DDSFilePicker = Ember.Component.extend({
     let onPick = this.get('filePicked');
     files.forEach(onPick);
   },
+  hasFiles: Ember.computed('resources', function() {
+    const children = this.get('resources');
+    if(children == null) {
+      return false;
+    }
+    return children.filterBy('isFile').get('length') > 0;
+  }),
   projectChanged: Ember.on('init', Ember.observer('project', function() {
     if(! this.get('project.id')) {
       return;

--- a/app/components/dds/dds-file-picker.js
+++ b/app/components/dds/dds-file-picker.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 const DDSFilePicker = Ember.Component.extend({
   project: null,
   store: Ember.inject.service(), // Needs access to store to query for children
-  resources: null, // Can be files or folders
+  children: null, // Can be files or folders
   filePicked: function(/* file */) {},
   selectedResources: null,
   actions: {
@@ -12,12 +12,12 @@ const DDSFilePicker = Ember.Component.extend({
     pickAllFilesClicked() { this.pickAllFiles(); }
   },
   pickAllFiles() {
-    let files = this.get('resources').filterBy('isFile');
+    let files = this.get('children').filterBy('isFile');
     let onPick = this.get('filePicked');
     files.forEach(onPick);
   },
-  hasFiles: Ember.computed('resources', function() {
-    const children = this.get('resources');
+  hasFiles: Ember.computed('children', function() {
+    const children = this.get('children');
     if(children == null) {
       return false;
     }
@@ -30,7 +30,7 @@ const DDSFilePicker = Ember.Component.extend({
     this.get('store').query('dds-resource', {
       project_id: this.get('project.id')
     }).then((resources) => {
-      this.set('resources', resources.sortBy('name'));
+      this.set('children', resources.sortBy('name'));
     });
   }))
 });

--- a/app/components/dds/dds-file-picker.js
+++ b/app/components/dds/dds-file-picker.js
@@ -4,16 +4,16 @@ const DDSFilePicker = Ember.Component.extend({
   project: null,
   store: Ember.inject.service(), // Needs access to store to query for children
   children: null, // Can be files or folders
-  filePicked: function(/* file */) {},
+  onPick: function(/* file */) {},
   selectedResources: null,
   actions: {
     // Passed down to each node
-    pickFile(file) { this.get('filePicked')(file); },
+    pickFile(file) { this.get('onPick')(file); },
     pickAllFilesClicked() { this.pickAllFiles(); }
   },
   pickAllFiles() {
     let files = this.get('children').filterBy('isFile');
-    let onPick = this.get('filePicked');
+    let onPick = this.get('onPick');
     files.forEach(onPick);
   },
   hasFiles: Ember.computed('children', function() {
@@ -36,7 +36,7 @@ const DDSFilePicker = Ember.Component.extend({
 });
 
 DDSFilePicker.reopenClass({
-  positionalParams: ['project', 'selectedResources', 'filePicked']
+  positionalParams: ['project', 'selectedResources', 'onPick']
 });
 
 export default DDSFilePicker;

--- a/app/components/dds/dds-file-picker.js
+++ b/app/components/dds/dds-file-picker.js
@@ -8,7 +8,13 @@ const DDSFilePicker = Ember.Component.extend({
   selectedResources: null,
   actions: {
     // Passed down to each node
-    pickFile(file) { this.get('filePicked')(file); }
+    pickFile(file) { this.get('filePicked')(file); },
+    pickAllFilesClicked() { this.pickAllFiles(); }
+  },
+  pickAllFiles() {
+    let files = this.get('resources').filterBy('isFile');
+    let onPick = this.get('filePicked');
+    files.forEach(onPick);
   },
   projectChanged: Ember.on('init', Ember.observer('project', function() {
     if(! this.get('project.id')) {

--- a/app/components/dds/dds-project-picker.js
+++ b/app/components/dds/dds-project-picker.js
@@ -3,6 +3,7 @@ import Ember from 'ember';
 const DDSProjectPicker = Ember.Component.extend({
   classNames: ['dds-project-picker'],
   selectedProject: null,
+  onPick: (/* dds-project */) => {},
   actions: {
     pick(project) {
       this.get('onPick')(project);

--- a/app/components/dds/dds-remove-button.js
+++ b/app/components/dds/dds-remove-button.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 const DDSRemoveButton = Ember.Component.extend({
   resource: null,
   tagName: 'span',
-  classNames: ['glyphicon','dds-remove-button', 'glyphicon-remove', 'small'],
+  classNames: ['glyphicon','dds-remove-button', 'glyphicon-remove', 'small', 'dds-button'],
   click() {
     this.sendAction();
   }

--- a/app/components/dds/dds-resource-header.js
+++ b/app/components/dds/dds-resource-header.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+  title: 'Select All Files',
+  icon: 'glyphicon-plus',
   tagName: 'span',
   classNames: ['dds-resource-header'],
   click() {

--- a/app/components/dds/dds-resource-header.js
+++ b/app/components/dds/dds-resource-header.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: 'span',
+  classNames: ['dds-resource-header'],
+  click() {
+    this.sendAction();
+  }
+});

--- a/app/components/dds/dds-resource-tree.js
+++ b/app/components/dds/dds-resource-tree.js
@@ -29,13 +29,13 @@ const DDSResourceTree = Ember.Component.extend({
     }
   }),
   expand(){
-    this.set('expanded', !this.get('expanded'));
+    this.toggleProperty('expanded');
   },
   pick() {
     this.get('onPick')(this.get('resource'));
   },
   actions: {
-    resourceClicked() {
+    clicked() {
       if(this.get('resource.isFile')) {
         this.pick();
       } else {

--- a/app/components/dds/dds-resource-tree.js
+++ b/app/components/dds/dds-resource-tree.js
@@ -8,6 +8,13 @@ const DDSResourceTree = Ember.Component.extend({
   children: null,
   onPick: () => {},
   store: Ember.inject.service('store'),
+  hasFiles: Ember.computed('children', function() {
+    const children = this.get('children');
+    if(children == null) {
+      return false;
+    }
+    return children.filterBy('isFile').get('length') > 0;
+  }),
   fetchedOnce: Ember.computed('children', function () {
     return this.get('children') != null;
   }),

--- a/app/components/dds/dds-resource-tree.js
+++ b/app/components/dds/dds-resource-tree.js
@@ -34,6 +34,11 @@ const DDSResourceTree = Ember.Component.extend({
   pick() {
     this.get('onPick')(this.get('resource'));
   },
+  pickAllFiles() {
+    let files = this.get('children').filterBy('isFile');
+    let onPick = this.get('onPick');
+    files.forEach(onPick);
+  },
 
   actions: {
     resourceClicked() {
@@ -43,6 +48,9 @@ const DDSResourceTree = Ember.Component.extend({
         this.expand();
       }
     },
+    pickAllFilesClicked() {
+      this.pickAllFiles();
+    }
   }
 });
 

--- a/app/components/dds/dds-resource-tree.js
+++ b/app/components/dds/dds-resource-tree.js
@@ -8,13 +8,6 @@ const DDSResourceTree = Ember.Component.extend({
   children: null,
   onPick: () => {},
   store: Ember.inject.service('store'),
-  hasFiles: Ember.computed('children', function() {
-    const children = this.get('children');
-    if(children == null) {
-      return false;
-    }
-    return children.filterBy('isFile').get('length') > 0;
-  }),
   fetchedOnce: Ember.computed('children', function () {
     return this.get('children') != null;
   }),
@@ -41,12 +34,6 @@ const DDSResourceTree = Ember.Component.extend({
   pick() {
     this.get('onPick')(this.get('resource'));
   },
-  pickAllFiles() {
-    let files = this.get('children').filterBy('isFile');
-    let onPick = this.get('onPick');
-    files.forEach(onPick);
-  },
-
   actions: {
     resourceClicked() {
       if(this.get('resource.isFile')) {
@@ -55,9 +42,6 @@ const DDSResourceTree = Ember.Component.extend({
         this.expand();
       }
     },
-    pickAllFilesClicked() {
-      this.pickAllFiles();
-    }
   }
 });
 

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -36,7 +36,7 @@ ul.tree li:last-child:before {
   border-left:1px solid rgb(100,100,100);
 }
 
-.dds-resource-node {
+.dds-resource-node, .dds-resource-header {
   cursor: pointer;
 }
 
@@ -51,4 +51,8 @@ a.clickable {
 span.is-disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.dds-button {
+  padding-right: 4px;
 }

--- a/app/templates/components/dds/dds-add-button.hbs
+++ b/app/templates/components/dds/dds-add-button.hbs
@@ -1,1 +1,1 @@
-&nbsp;{{yield}}
+{{yield}}

--- a/app/templates/components/dds/dds-expand-button.hbs
+++ b/app/templates/components/dds/dds-expand-button.hbs
@@ -1,1 +1,1 @@
-&nbsp;{{yield}}
+{{yield}}

--- a/app/templates/components/dds/dds-file-picker.hbs
+++ b/app/templates/components/dds/dds-file-picker.hbs
@@ -1,7 +1,7 @@
 <ul class="tree list-unstyled">
 {{#if resources}}
   <li class="dds-resource-list-header">
-    {{dds/dds-resource-header action='pickAllFilesClicked' title='Pick All Files' icon='glyphicon-plus'}}
+    {{dds/dds-resource-header action='pickAllFilesClicked'}}
   </li>
 {{/if}}
   {{#each resources as |resource|}}

--- a/app/templates/components/dds/dds-file-picker.hbs
+++ b/app/templates/components/dds/dds-file-picker.hbs
@@ -1,5 +1,5 @@
 <ul class="tree list-unstyled">
-{{#if resources}}
+{{#if hasFiles}}
   <li class="dds-resource-list-header">
     {{dds/dds-resource-header action='pickAllFilesClicked'}}
   </li>

--- a/app/templates/components/dds/dds-file-picker.hbs
+++ b/app/templates/components/dds/dds-file-picker.hbs
@@ -4,8 +4,8 @@
     {{dds/dds-resource-header action='pickAllFilesClicked'}}
   </li>
 {{/if}}
-  {{#each resources as |resource|}}
-  <li class="dds-resource-list-item">{{dds/dds-resource-tree resource selectedResources (action 'pickFile')}}</li>
+  {{#each children as |child|}}
+  <li class="dds-resource-list-item">{{dds/dds-resource-tree child selectedResources (action 'pickFile')}}</li>
 {{/each}}
 </ul>
 {{yield}}

--- a/app/templates/components/dds/dds-file-picker.hbs
+++ b/app/templates/components/dds/dds-file-picker.hbs
@@ -1,5 +1,10 @@
 <ul class="tree list-unstyled">
-{{#each resources as |resource|}}
+{{#if resources}}
+  <li class="dds-resource-list-header">
+    {{dds/dds-resource-header action='pickAllFilesClicked' title='Pick All Files' icon='glyphicon-plus'}}
+  </li>
+{{/if}}
+  {{#each resources as |resource|}}
   <li class="dds-resource-list-item">{{dds/dds-resource-tree resource selectedResources (action 'pickFile')}}</li>
 {{/each}}
 </ul>

--- a/app/templates/components/dds/dds-remove-button.hbs
+++ b/app/templates/components/dds/dds-remove-button.hbs
@@ -1,1 +1,1 @@
-&nbsp;{{yield}}
+{{yield}}

--- a/app/templates/components/dds/dds-resource-header.hbs
+++ b/app/templates/components/dds/dds-resource-header.hbs
@@ -1,0 +1,3 @@
+<span class="glyphicon {{icon}} dds-button"></span>
+<span>{{title}}</span>
+

--- a/app/templates/components/dds/dds-resource-header.hbs
+++ b/app/templates/components/dds/dds-resource-header.hbs
@@ -1,3 +1,2 @@
 <span class="glyphicon {{icon}} dds-button"></span>
 <span>{{title}}</span>
-

--- a/app/templates/components/dds/dds-resource-tree.hbs
+++ b/app/templates/components/dds/dds-resource-tree.hbs
@@ -10,7 +10,7 @@
   <ul class="dds-resource-list list-unstyled">
     {{#if children}}
       <li class="dds-resource-list-header">
-        {{dds/dds-resource-header action='pickAllFilesClicked' title='Pick All Files' icon='glyphicon-plus'}}
+        {{dds/dds-resource-header action='pickAllFilesClicked'}}
       </li>
     {{/if}}
     {{#each children as |child|}}

--- a/app/templates/components/dds/dds-resource-tree.hbs
+++ b/app/templates/components/dds/dds-resource-tree.hbs
@@ -7,15 +7,6 @@
   {{/if}}
 {{/dds/dds-resource-node}}
 {{#if expanded}}
-  <ul class="dds-resource-list list-unstyled">
-    {{#if hasFiles}}
-      <li class="dds-resource-list-header">
-        {{dds/dds-resource-header action='pickAllFilesClicked'}}
-      </li>
-    {{/if}}
-    {{#each children as |child|}}
-      <li class="dds-resource-list-item">{{dds/dds-resource-tree child selectedResources (action onPick)}}</li>
-    {{/each}}
-  </ul>
+  {{dds/dds-file-picker project selectedResources (action onPick) resources=children}}
 {{/if}}
 {{yield}}

--- a/app/templates/components/dds/dds-resource-tree.hbs
+++ b/app/templates/components/dds/dds-resource-tree.hbs
@@ -7,6 +7,6 @@
   {{/if}}
 {{/dds/dds-resource-node}}
 {{#if expanded}}
-  {{dds/dds-file-picker project selectedResources (action onPick) resources=children}}
+  {{dds/dds-file-picker project selectedResources (action onPick) children=children}}
 {{/if}}
 {{yield}}

--- a/app/templates/components/dds/dds-resource-tree.hbs
+++ b/app/templates/components/dds/dds-resource-tree.hbs
@@ -1,4 +1,4 @@
-{{#dds/dds-resource-node resource expanded selectedResources action='resourceClicked'}}
+{{#dds/dds-resource-node resource expanded selectedResources action='clicked'}}
   {{! The node yields to allow the caller (us) to pick what icon/button to render}}
   {{#if resource.isFolder}}
     {{dds/dds-expand-button expanded}}

--- a/app/templates/components/dds/dds-resource-tree.hbs
+++ b/app/templates/components/dds/dds-resource-tree.hbs
@@ -1,5 +1,5 @@
 {{#dds/dds-resource-node resource expanded selectedResources action='resourceClicked'}}
-  {{! The node yields to allow the caller to pick what icon/button to render}}
+  {{! The node yields to allow the caller (us) to pick what icon/button to render}}
   {{#if resource.isFolder}}
     {{dds/dds-expand-button expanded}}
   {{else}}
@@ -8,6 +8,11 @@
 {{/dds/dds-resource-node}}
 {{#if expanded}}
   <ul class="dds-resource-list list-unstyled">
+    {{#if children}}
+      <li class="dds-resource-list-header">
+        {{dds/dds-resource-header action='pickAllFilesClicked' title='Pick All Files' icon='glyphicon-plus'}}
+      </li>
+    {{/if}}
     {{#each children as |child|}}
       <li class="dds-resource-list-item">{{dds/dds-resource-tree child selectedResources (action onPick)}}</li>
     {{/each}}

--- a/app/templates/components/dds/dds-resource-tree.hbs
+++ b/app/templates/components/dds/dds-resource-tree.hbs
@@ -8,7 +8,7 @@
 {{/dds/dds-resource-node}}
 {{#if expanded}}
   <ul class="dds-resource-list list-unstyled">
-    {{#if children}}
+    {{#if hasFiles}}
       <li class="dds-resource-list-header">
         {{dds/dds-resource-header action='pickAllFilesClicked'}}
       </li>

--- a/app/utils/file-item-list.js
+++ b/app/utils/file-item-list.js
@@ -21,6 +21,7 @@ const FileItem = Ember.Object.extend({
 
 const FileItemList = Ember.Object.extend({
   content: null,
+  unique: true,
   init() {
     this._super(...arguments);
     if(Ember.isEmpty(this.get('content'))) {
@@ -29,7 +30,14 @@ const FileItemList = Ember.Object.extend({
   },
   groupSize: 2,
   addFileItem(fileItem) {
-    this.get('content').pushObject(fileItem);
+    const content = this.get('content');
+    const unique = this.get('unique');
+    if(unique && content.includes(fileItem)) {
+      // we already have this item and must be unique
+      return false;
+    } else {
+      this.get('content').pushObject(fileItem);
+    }
   },
   removeFileItem(groupIndex, fileIndex) {
     let index = this.get('groupSize') * groupIndex + fileIndex;

--- a/app/utils/file-item-list.js
+++ b/app/utils/file-item-list.js
@@ -29,14 +29,25 @@ const FileItemList = Ember.Object.extend({
     }
   },
   groupSize: 2,
+  includesFileItem(fileItem) {
+    // Check inclusion based on the ddsFile property by default
+    // If the fileItem does not have this property, fallback to object equality
+    const ddsFile = Ember.get(fileItem, 'ddsFile');
+    if(ddsFile) {
+      return this.get('ddsFiles').includes(ddsFile);
+    } else {
+      return this.get('content').includes(fileItem);
+    }
+  },
   addFileItem(fileItem) {
     const content = this.get('content');
     const unique = this.get('unique');
-    if(unique && content.includes(fileItem)) {
-      // we already have this item and must be unique
+    const exists = this.includesFileItem(fileItem);
+    if(unique && exists) {
+      // We require uniqueness but already have this fileItem
       return false;
     } else {
-      this.get('content').pushObject(fileItem);
+      return content.pushObject(fileItem);
     }
   },
   removeFileItem(groupIndex, fileIndex) {

--- a/tests/integration/components/dds/dds-file-picker-test.js
+++ b/tests/integration/components/dds/dds-file-picker-test.js
@@ -12,10 +12,10 @@ test('it renders', function(assert) {
 });
 
 test('it renders dds-resource-list-header button only when there are files', function(assert) {
-  this.set('resources', [Ember.Object.create({isFile: true})]);
-  this.render(hbs`{{dds/dds-file-picker resources=resources}}`);
+  this.set('children', [Ember.Object.create({isFile: true})]);
+  this.render(hbs`{{dds/dds-file-picker children=children}}`);
   assert.equal(this.$('.dds-resource-list-header').length, 1);
-  this.set('resources', [Ember.Object.create({isFile: false})]);
-  this.render(hbs`{{dds/dds-file-picker resources=resources}}`);
+  this.set('children', [Ember.Object.create({isFile: false})]);
+  this.render(hbs`{{dds/dds-file-picker children=children}}`);
   assert.equal(this.$('.dds-resource-list-header').length, 0);
 });

--- a/tests/integration/components/dds/dds-file-picker-test.js
+++ b/tests/integration/components/dds/dds-file-picker-test.js
@@ -1,4 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('dds/dds-file-picker', 'Integration | Component | dds/dds file picker', {
@@ -8,4 +9,13 @@ moduleForComponent('dds/dds-file-picker', 'Integration | Component | dds/dds fil
 test('it renders', function(assert) {
   this.render(hbs`{{dds/dds-file-picker}}`);
   assert.ok(this.$().text());
+});
+
+test('it renders dds-resource-list-header button only when there are files', function(assert) {
+  this.set('resources', [Ember.Object.create({isFile: true})]);
+  this.render(hbs`{{dds/dds-file-picker resources=resources}}`);
+  assert.equal(this.$('.dds-resource-list-header').length, 1);
+  this.set('resources', [Ember.Object.create({isFile: false})]);
+  this.render(hbs`{{dds/dds-file-picker resources=resources}}`);
+  assert.equal(this.$('.dds-resource-list-header').length, 0);
 });

--- a/tests/integration/components/dds/dds-resource-header-test.js
+++ b/tests/integration/components/dds/dds-resource-header-test.js
@@ -1,0 +1,20 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('dds/dds-resource-header', 'Integration | Component | dds/dds resourceheader', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  this.render(hbs`{{dds/dds-resource-header title='Header Title' icon='iconclass'}}`);
+  assert.equal(this.$().text().trim(), 'Header Title');
+  assert.equal(this.$('.iconclass').length, 1);
+});
+
+test('it sends action on click', function(assert) {
+  this.set('testAction', () => {
+    assert.ok(true);
+  });
+  this.render(hbs`{{dds/dds-resource-header action=(action testAction)}}`);
+  this.$('.dds-resource-header').click();
+});

--- a/tests/integration/components/dds/dds-resource-tree-test.js
+++ b/tests/integration/components/dds/dds-resource-tree-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import StoreStub from '../../../helpers/store-stub';
-
+import Ember from 'ember';
 
 moduleForComponent('dds/dds-resource-tree', 'Integration | Component | dds/dds resource tree', {
   integration: true,
@@ -10,7 +10,10 @@ moduleForComponent('dds/dds-resource-tree', 'Integration | Component | dds/dds r
     this.inject.service('store', {as: 'store'});
     this.get('store').reset();
     this.set('store.queryFunction', function() {
-      return [{name: 'file1.txt', kind: 'dds-file'}, {name: 'file2.txt', kind: 'dds-file'}];
+      return [
+        {name: 'file1.txt', kind: 'dds-file', isFile: true},
+        {name: 'file2.txt', kind: 'dds-file', isFile: true}
+        ];
     });
   }
 });
@@ -46,3 +49,11 @@ test('it fetches only on first expansion', function(assert) {
   assert.equal(this.get('store.queryCount'), 1);
 });
 
+test('it renders dds-resource-list-header button only when there are files', function(assert) {
+  this.set('children', [Ember.Object.create({isFile: true})]);
+  this.render(hbs`{{dds/dds-resource-tree children=children expanded=true}}`);
+  assert.equal(this.$('.dds-resource-list-header').length, 1);
+  this.set('children', [Ember.Object.create({isFile: false})]);
+  this.render(hbs`{{dds/dds-resource-tree children=children expanded=true}}`);
+  assert.equal(this.$('.dds-resource-list-header').length, 0);
+});

--- a/tests/integration/components/dds/dds-resource-tree-test.js
+++ b/tests/integration/components/dds/dds-resource-tree-test.js
@@ -31,11 +31,13 @@ test('it fetches only on first expansion', function(assert) {
   this.render(hbs`{{dds/dds-resource-tree resource store=store expanded=expanded}}`);
   assert.equal(this.get('expanded'), false, 'should not be initially expanded');
   assert.equal(this.$('li.dds-resource-list-item').length, 0, 'should not have any dds-resource-list-items yet');
+  assert.equal(this.$('li.dds-resource-list-header').length, 0, 'should not show the resource list header yet');
   assert.equal(this.get('store.queryCount'), 0, 'store should not have been queried yet');
   this.set('expanded', true);
   // Used to send a click to the dds-resource-name but that doesn't work on the first pass anymore
   assert.equal(this.get('expanded'), true, 'Should now be expanded');
   assert.equal(this.$('li.dds-resource-list-item').length, 2);
+  assert.equal(this.$('li.dds-resource-list-header').length, 1);
   assert.equal(this.get('store.queryCount'), 1, 'should have registered one query');
   this.$('.dds-resource-name').click();
   assert.equal(this.get('expanded'), false);
@@ -43,3 +45,4 @@ test('it fetches only on first expansion', function(assert) {
   assert.equal(this.get('expanded'), true);
   assert.equal(this.get('store.queryCount'), 1);
 });
+

--- a/tests/unit/components/dds/dds-file-picker-test.js
+++ b/tests/unit/components/dds/dds-file-picker-test.js
@@ -26,6 +26,6 @@ test('it sorts files by name', function(assert) {
     component.set('project', Ember.Object.create({id:7}));
   });
   Ember.run(() => {
-    assert.deepEqual(component.get('resources').mapBy('name'), ['A', 'B', 'C', 'D']);
+    assert.deepEqual(component.get('children').mapBy('name'), ['A', 'B', 'C', 'D']);
   });
 });

--- a/tests/unit/utils/file-item-list-test.js
+++ b/tests/unit/utils/file-item-list-test.js
@@ -130,3 +130,23 @@ test('it allows duplicates when configured', function(assert) {
   fileGroupList.addFileItem(if1);
   assert.equal(fileGroupList.get('content.length'), 2);
 });
+
+test('it checks inclusion based on ddsFile', function(assert) {
+  // Create two different objects with the same ddsFile
+  const f1 = Ember.Object.create({ddsFile: 'abc', id: 1});
+  const f2 = Ember.Object.create({ddsFile: 'abc', id: 2});
+  const f3 = Ember.Object.create({ddsFile: 'def', id: 1});
+  assert.notEqual(f1, f2);
+  assert.equal(f1.get('ddsFile'), f2.get('ddsFile'));
+  const fileItemList = FileItemList.create({content: [f1]});
+  assert.ok(fileItemList.includesFileItem(f2));
+  assert.notOk(fileItemList.includesFileItem(f3));
+});
+
+test('it falls back to simple inclusion when ddsFile not present', function(assert) {
+  const f1 = Ember.Object.create();
+  const f2 = Ember.Object.create();
+  assert.notEqual(f1, f2);
+  const fileItemList = FileItemList.create({content: [f1]});
+  assert.notOk(fileItemList.includesFileItem(f2));
+});

--- a/tests/unit/utils/file-item-list-test.js
+++ b/tests/unit/utils/file-item-list-test.js
@@ -114,3 +114,19 @@ test('it creates flat list of inputFiles from fileItems regardless of group size
   fileGroupList.addFileItem(if4);
   assert.deepEqual(fileGroupList.get('inputFiles'), ['if1','if2','if3','if4']);
 });
+
+test('it prevents duplicates by default', function(assert) {
+  const if1 = Ember.Object.create({inputFile: 'if1'});
+  const fileGroupList = FileItemList.create({groupSize: 1, content: [if1]});
+  assert.equal(fileGroupList.get('content.length'), 1);
+  fileGroupList.addFileItem(if1);
+  assert.equal(fileGroupList.get('content.length'), 1);
+});
+
+test('it allows duplicates when configured', function(assert) {
+  const if1 = Ember.Object.create({inputFile: 'if1'});
+  const fileGroupList = FileItemList.create({groupSize: 1, unique: false, content: [if1]});
+  assert.equal(fileGroupList.get('content.length'), 1);
+  fileGroupList.addFileItem(if1);
+  assert.equal(fileGroupList.get('content.length'), 2);
+});


### PR DESCRIPTION
Adds a "Select all files" button to each folder in the file picker, improving usability of picking lots of files when directories are nicely organized

Fixes #47 