### PR TITLE
Replace charge estimate with analysis share group info

### DIFF
--- a/app/models/job.js
+++ b/app/models/job.js
@@ -13,6 +13,7 @@ export default DS.Model.extend({
   vmProjectName: DS.attr('string'),
   jobOrder: DS.attr('string'), // This is JSON, no need to test it
   stageGroup: DS.belongsTo('job-file-stage-group'),
+  shareGroup: DS.belongsTo('share-group'),
   isNew: Ember.computed('state', function() {
     return this.get('state') === 'N';
   }),

--- a/app/models/share-group.js
+++ b/app/models/share-group.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  name: DS.attr('string'),
+});

--- a/app/templates/components/job-controls.hbs
+++ b/app/templates/components/job-controls.hbs
@@ -9,7 +9,12 @@
     {{else if operation}}
       {{#bs-alert type="success"}}<span class="success-message">The job has been {{operation}}.</span>{{/bs-alert}}
     {{else if job.isAuthorized}}
-      {{#bs-alert type="info"}}<span class="info-message">Your job is ready. Click <strong>Start</strong> to submit. You will be charged at a rate of $x per hour of computation. Results will be uploaded to Duke Data Service.</span>{{/bs-alert}}
+      {{#bs-alert type="info"}}<span class="info-message">Your job is ready.
+          Click <strong>Start</strong> to submit.
+          Results will be reviewed by {{job.shareGroup.name}}.
+          After review, the results will be delivered to you through Duke Data Service.
+      </span>{{/bs-alert}}
+
     {{/if}}
   </div>
   {{#if job.isNew}}

--- a/tests/unit/models/job-test.js
+++ b/tests/unit/models/job-test.js
@@ -52,6 +52,7 @@ test('it computes isErrored', function(assert) {
 testRelationship('job', {key: 'workflowVersion', kind: 'belongsTo', type: 'workflow-version'});
 testRelationship('job', {key: 'outputDir', kind: 'belongsTo', type: 'job-output-dir'});
 testRelationship('job', {key: 'stageGroup', kind: 'belongsTo', type: 'job-file-stage-group'});
+testRelationship('job', {key: 'shareGroup', kind: 'belongsTo', type: 'share-group'});
 
 test('it sends actions to the adapter', function(assert) {
   assert.expect(15); // 5asserts for each action

--- a/tests/unit/models/job-test.js
+++ b/tests/unit/models/job-test.js
@@ -8,7 +8,8 @@ moduleForModel('job', 'Unit | Model | job', {
     'model:workflow-version',
     'model:job-output-dir',
     'model:job-error',
-    'model:job-file-stage-group'
+    'model:job-file-stage-group',
+    'model:share-group'
   ]
 });
 

--- a/tests/unit/models/share-group-test.js
+++ b/tests/unit/models/share-group-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('share-group', 'Unit | Model | share group', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/serializers/job-test.js
+++ b/tests/unit/serializers/job-test.js
@@ -7,7 +7,8 @@ moduleForModel('job', 'Unit | Serializer | job', {
     'model:workflow-version',
     'model:job-output-dir',
     'model:job-error',
-    'model:job-file-stage-group'
+    'model:job-file-stage-group',
+    'model:share-group',
   ]
 });
 


### PR DESCRIPTION
Displays group that will be performing analysis on resulting data.
This name displayed value comes from bespin-api.
<img width="694" alt="screen shot 2017-08-28 at 10 27 00 am" src="https://user-images.githubusercontent.com/1024463/29777871-7dcda032-8bdb-11e7-8daf-bc4ff39fe539.png">
Requires https://github.com/Duke-GCB/bespin-api/pull/70.
