### PR TITLE
Show build-answer-set errors from bespin-api

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -31,5 +31,8 @@ export default DS.RESTAdapter.extend(DataAdapterMixin, {
     let dasherized = Ember.String.dasherize(type);
     let pluralized = Ember.String.pluralize(dasherized);
     return pluralized;
-  }
+  },
+  isInvalid(status) {
+    return status === 400;
+  },
 });

--- a/app/components/error-panel.js
+++ b/app/components/error-panel.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  errors: []
+});

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -56,3 +56,7 @@ span.is-disabled {
 .dds-button {
   padding-right: 4px;
 }
+
+.error-panel {
+  color: darkred;
+}

--- a/app/templates/components/error-panel.hbs
+++ b/app/templates/components/error-panel.hbs
@@ -1,0 +1,13 @@
+{{#if errors}}
+    <div class="error-panel alert alert-danger">
+        <h4>Errors</h4>
+        <ul>
+          {{#each errors as |error|}}
+              <li>{{error.attribute}} - {{error.message}}</li>
+          {{/each}}
+        </ul>
+        {{yield}}
+    </div>
+{{/if}}
+
+

--- a/app/templates/components/error-panel.hbs
+++ b/app/templates/components/error-panel.hbs
@@ -1,9 +1,8 @@
 {{#if errors}}
-    <div class="error-panel alert alert-danger">
-        <h4>Errors</h4>
+    <div class="error-panel">
         <ul>
           {{#each errors as |error|}}
-              <li>{{error.attribute}} - {{error.message}}</li>
+              <li>{{error.message}}</li>
           {{/each}}
         </ul>
         {{yield}}

--- a/app/templates/components/questionnaire/fund-code.hbs
+++ b/app/templates/components/questionnaire/fund-code.hbs
@@ -3,6 +3,7 @@
     {{#form.group class='job-fund-code-group'}}
         <label for="{{concat elementId '-fundCode'}}">Fund Code:</label>
       {{input class='form-control fund-code-input' id=(concat elementId '-fundCode') placeholder='Fund code charged for this job' value=answerSet.fundCode}}
+      {{error-panel errors=answerSet.errors.fundCode}}
     {{/form.group}}
   {{/bs-form}}
 </div>

--- a/app/templates/components/questionnaire/job-name.hbs
+++ b/app/templates/components/questionnaire/job-name.hbs
@@ -3,6 +3,7 @@
     {{#form.group class='job-name-group'}}
       <label for="{{concat elementId '-jobName'}}">Job Name:</label>
       {{input class='form-control job-name-input' id=(concat elementId '-jobName') placeholder='Enter name for this job' value=answerSet.jobName}}
+      {{error-panel errors=answerSet.errors.jobName}}
     {{/form.group}}
   {{/bs-form}}
 </div>

--- a/app/templates/jobs/new/build-answer-set.hbs
+++ b/app/templates/jobs/new/build-answer-set.hbs
@@ -1,14 +1,18 @@
 {{questionnaire/answer-form model}}
 
+{{! move this to another component }}
+{{#if model.errors}}
+  <div class="error-panel alert alert-danger">
+      <h4>Errors</h4>
+      <ul>
+        {{#each model.errors.jobName as |error|}}
+          <li>{{error.attribute}} - {{error.message}}</li>
+        {{/each}}
+      </ul>
+  </div>
+{{/if}}
+
 {{#bs-button type="default" onClick=(action 'back') class="back-button"}}Back{{/bs-button}}
 {{#bs-button type="primary" onClick=(action 'saveAndCreateJob') class="pull-right next-button"}}Save{{/bs-button}}
 
-{{! move this to another component }}
-{{#if model.errors}}
-  <ul class="job-answer-set-errors">
-    {{#each model.errors as |error|}}
-      <li>{{error}}</li>
-    {{/each}}
-  </ul>
-{{/if}}
 {{outlet}}

--- a/app/templates/jobs/new/build-answer-set.hbs
+++ b/app/templates/jobs/new/build-answer-set.hbs
@@ -1,7 +1,5 @@
 {{questionnaire/answer-form model}}
 
-{{error-panel errors=model.errors}}
-
 {{#bs-button type="default" onClick=(action 'back') class="back-button"}}Back{{/bs-button}}
 {{#bs-button type="primary" onClick=(action 'saveAndCreateJob') class="pull-right next-button"}}Save{{/bs-button}}
 

--- a/app/templates/jobs/new/build-answer-set.hbs
+++ b/app/templates/jobs/new/build-answer-set.hbs
@@ -5,7 +5,7 @@
   <div class="error-panel alert alert-danger">
       <h4>Errors</h4>
       <ul>
-        {{#each model.errors.jobName as |error|}}
+        {{#each model.errors as |error|}}
           <li>{{error.attribute}} - {{error.message}}</li>
         {{/each}}
       </ul>

--- a/app/templates/jobs/new/build-answer-set.hbs
+++ b/app/templates/jobs/new/build-answer-set.hbs
@@ -1,16 +1,6 @@
 {{questionnaire/answer-form model}}
 
-{{! move this to another component }}
-{{#if model.errors}}
-  <div class="error-panel alert alert-danger">
-      <h4>Errors</h4>
-      <ul>
-        {{#each model.errors as |error|}}
-          <li>{{error.attribute}} - {{error.message}}</li>
-        {{/each}}
-      </ul>
-  </div>
-{{/if}}
+{{error-panel errors=model.errors}}
 
 {{#bs-button type="default" onClick=(action 'back') class="back-button"}}Back{{/bs-button}}
 {{#bs-button type="primary" onClick=(action 'saveAndCreateJob') class="pull-right next-button"}}Save{{/bs-button}}

--- a/tests/integration/components/error-panel-test.js
+++ b/tests/integration/components/error-panel-test.js
@@ -1,0 +1,32 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('error-panel', 'Integration | Component | error panel', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.set('noErrors', [])
+  this.set('oneError', [{
+    'attribute': 'jobName',
+    'message': 'required',
+  }]);
+
+  this.render(hbs`{{error-panel errors=noErrors}}`);
+  assert.equal(this.$().text().trim(), '');
+
+  this.render(hbs`{{error-panel errors=oneError}}`);
+  assert.equal(this.$('li').text(), 'jobName - required');
+
+
+  this.render(hbs`
+    {{#error-panel errors=oneError}}
+      <span class='childtext'>template block text</span>
+    {{/error-panel}}
+  `);
+
+  assert.equal(this.$('.childtext').text().trim(), 'template block text');
+});

--- a/tests/integration/components/error-panel-test.js
+++ b/tests/integration/components/error-panel-test.js
@@ -19,7 +19,7 @@ test('it renders', function(assert) {
   assert.equal(this.$().text().trim(), '');
 
   this.render(hbs`{{error-panel errors=oneError}}`);
-  assert.equal(this.$('li').text(), 'jobName - required');
+  assert.equal(this.$('li').text(), 'required');
 
 
   this.render(hbs`


### PR DESCRIPTION
Changes the adapters/application so will display errors for status code 400 (status code returned by django rest framework). Currently emberjs expects the 422 status code.