### PR TITLE
Shows errors for bad authorization codes

### DIFF
--- a/app/components/job-authorize.js
+++ b/app/components/job-authorize.js
@@ -3,6 +3,15 @@ import Ember from 'ember';
 const JobAuthorize = Ember.Component.extend({
   tagName: 'div',
   classNames: ['job-authorize'],
+  errors: [],
+  formGroupClassNames: Ember.computed('errors.[]', function() {
+    const base = 'job-authorize-group form-inline';
+    if(this.get('errors.length') == 0) {
+      return base;
+    } else {
+      return `${base} has-error`;
+    }
+  }),
   job: null,
   _token: '',
   token: Ember.computed('job.hasAuthorization', 'job.runToken', '_token', {
@@ -37,7 +46,9 @@ const JobAuthorize = Ember.Component.extend({
   actions: {
     authorize() {
       const token = this.get('token');
-      this.get('job').authorize(token);
+      this.get('job').authorize(token).then(()=> { /* succeeded */ }, (error) => {
+        this.set('errors', error.errors);
+      });
     }
   }
 });

--- a/app/templates/components/job-authorize.hbs
+++ b/app/templates/components/job-authorize.hbs
@@ -1,9 +1,16 @@
 {{#bs-form as |form|}}
-  {{#form.group class='job-authorize-group form-inline' }}
+  {{#form.group class=formGroupClassNames }}
       <label for="authorize-job">Authorization Code:</label>
       {{input class='form-control job-name-input' id='authorize-job'
               value=token
               disabled=job.hasAuthorization}}
       {{#bs-button type='primary' onClick=(action "authorize") disabled=job.hasAuthorization}}Authorize{{/bs-button}}
+      {{#if errors}}
+        <span class="help-block">
+        {{#each errors as |error|}}
+          {{error.detail}}
+        {{/each}}
+        </span>
+      {{/if}}
   {{/form.group}}
 {{/bs-form}}

--- a/tests/integration/components/job-authorize-test.js
+++ b/tests/integration/components/job-authorize-test.js
@@ -10,7 +10,8 @@ let MockJob = Ember.Object.extend({
   token: '',
   authorized: false,
   authorize: function () {
-    this.set('authorized', true)
+    this.set('authorized', true);
+    return Ember.RSVP.resolve({});
   }
 });
 
@@ -38,5 +39,14 @@ test('it disables input and button when job already has authorization', function
   this.render(hbs`{{job-authorize job}}`);
   assert.ok(this.$('.job-authorize input').attr('disabled'));
   assert.ok(this.$('.job-authorize button').attr('disabled'));
+});
 
+test('it displays error elements when there are errors', function(assert) {
+  this.render(hbs`{{job-authorize}}`);
+  assert.equal(this.$('.has-error').length, 0);
+  assert.equal(this.$('.help-block').length, 0);
+  this.set('errors', [1,2,3]);
+  this.render(hbs`{{job-authorize errors=errors}}`);
+  assert.equal(this.$('.has-error').length, 1);
+  assert.equal(this.$('.help-block').length, 1);
 });

--- a/tests/unit/components/job-authorize-test.js
+++ b/tests/unit/components/job-authorize-test.js
@@ -29,3 +29,24 @@ test('setting the token on authorized jobs does not change it', function(assert)
   assert.equal(jobAuthorize.get('token'), 'jobRunToken');
   assert.equal(mockJob.get('runToken'), 'jobRunToken');
 });
+
+test('errors from job.authorize are set on the component', function(assert) {
+  const mockError = Ember.Object.create({
+    status: 400,
+    detail: 'This token is not valid.'
+  });
+  const mockJob = Ember.Object.create({
+    authorize(token) {
+      assert.equal(token, 'auth-token');
+      return Ember.RSVP.reject({errors: [mockError]});
+    }
+  });
+  let jobAuthorize = this.subject({job: mockJob});
+  Ember.run(() => {
+    jobAuthorize.set('token', 'auth-token');
+    jobAuthorize.send('authorize');
+  });
+  Ember.run(() => {
+    assert.deepEqual(jobAuthorize.get('errors'), [mockError]);
+  });
+});


### PR DESCRIPTION
- Captures errors from the /jobs/:id/authorize call and displays them on the job-authorize form.
- Adds `has-error` class to the `.form-group`
- displays each error's `detail` below the field in a `span.help-block`

Fixes #78 