### PR TITLE
Displays loading/empty for dds projects in dds-projects-files-picker

### DIFF
--- a/app/components/dds/dds-loading-indicator.js
+++ b/app/components/dds/dds-loading-indicator.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-  tagName: 'li',
+  tagName: 'span',
   classNames: ['dds-loading-indicator'],
 });

--- a/app/components/dds/dds-no-projects.js
+++ b/app/components/dds/dds-no-projects.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: 'div',
+  classNames: ['alert','alert-danger']
+});

--- a/app/components/dds/dds-project-files-picker.js
+++ b/app/components/dds/dds-project-files-picker.js
@@ -6,6 +6,14 @@ const DDSProjectFilesPicker = Ember.Component.extend({
   selectedResources: null,
   formatSettings: null,
   onFilePicked: (/* file */) => {},
+  isLoading: Ember.computed('projects', function () {
+    const projects = this.get('projects');
+    return projects === null;
+  }),
+  isEmpty: Ember.computed('projects.length', function() {
+    const length = this.get('projects.length');
+    return length === 0;
+  }),
   actions: {
     projectChanged(project) {
       this.set('project', project);

--- a/app/templates/components/dds/dds-file-picker.hbs
+++ b/app/templates/components/dds/dds-file-picker.hbs
@@ -10,7 +10,7 @@
   </li>
 {{/each}}
 {{#if isLoading}}
-  {{dds/dds-loading-indicator}}
+  {{#dds/dds-loading-indicator}}Loading...{{/dds/dds-loading-indicator}}
 {{/if}}
 </ul>
 {{yield}}

--- a/app/templates/components/dds/dds-file-picker.hbs
+++ b/app/templates/components/dds/dds-file-picker.hbs
@@ -10,7 +10,9 @@
   </li>
 {{/each}}
 {{#if isLoading}}
-  {{#dds/dds-loading-indicator}}Loading...{{/dds/dds-loading-indicator}}
+  <li>
+    {{#dds/dds-loading-indicator}}Loading...{{/dds/dds-loading-indicator}}
+  </li>
 {{/if}}
 </ul>
 {{yield}}

--- a/app/templates/components/dds/dds-loading-indicator.hbs
+++ b/app/templates/components/dds/dds-loading-indicator.hbs
@@ -1,2 +1,2 @@
 <span class="glyphicon glyphicon-refresh spinning" aria-hidden="true"></span>
-<span>Loading...</span>
+{{yield}}

--- a/app/templates/components/dds/dds-no-projects.hbs
+++ b/app/templates/components/dds/dds-no-projects.hbs
@@ -1,0 +1,1 @@
+No projects found. Please upload your data to <a href="https://dataservice.duke.edu">Duke Data Service</a> in order to use Bespin.

--- a/app/templates/components/dds/dds-project-files-picker.hbs
+++ b/app/templates/components/dds/dds-project-files-picker.hbs
@@ -1,15 +1,15 @@
 {{#bs-form as |form|}}
   {{yield}}
-  {{#form.group class='select-project'}}
-    {{#if isLoading}}
-      LOADING
-    {{else if isEmpty}}
-      NO PROJECTS
-    {{else}}
+  {{#if isLoading}}
+    {{#dds/dds-loading-indicator}}Loading Projects...{{/dds/dds-loading-indicator}}
+  {{else if isEmpty}}
+    {{dds/dds-no-projects}}
+  {{else}}
+    {{#form.group class='select-project'}}
       {{dds/dds-project-picker projects project (action 'projectChanged')}}
-    {{/if}}
   {{/form.group}}
   {{#form.group class='select-files'}}
     {{dds/dds-file-picker project selectedResources (action 'filePicked') formatSettings=formatSettings}}
   {{/form.group}}
+  {{/if}}
 {{/bs-form}}

--- a/app/templates/components/dds/dds-project-files-picker.hbs
+++ b/app/templates/components/dds/dds-project-files-picker.hbs
@@ -1,7 +1,9 @@
 {{#bs-form as |form|}}
   {{yield}}
   {{#if isLoading}}
-    {{#dds/dds-loading-indicator}}Loading Projects...{{/dds/dds-loading-indicator}}
+    <span class="form-control" disabled>
+      {{#dds/dds-loading-indicator}}Loading Projects...{{/dds/dds-loading-indicator}}
+    </span>
   {{else if isEmpty}}
     {{dds/dds-no-projects}}
   {{else}}

--- a/app/templates/components/dds/dds-project-files-picker.hbs
+++ b/app/templates/components/dds/dds-project-files-picker.hbs
@@ -1,7 +1,13 @@
 {{#bs-form as |form|}}
   {{yield}}
   {{#form.group class='select-project'}}
-    {{dds/dds-project-picker projects project (action 'projectChanged')}}
+    {{#if isLoading}}
+      LOADING
+    {{else if isEmpty}}
+      NO PROJECTS
+    {{else}}
+      {{dds/dds-project-picker projects project (action 'projectChanged')}}
+    {{/if}}
   {{/form.group}}
   {{#form.group class='select-files'}}
     {{dds/dds-file-picker project selectedResources (action 'filePicked') formatSettings=formatSettings}}

--- a/tests/integration/components/dds/dds-loading-indicator-test.js
+++ b/tests/integration/components/dds/dds-loading-indicator-test.js
@@ -6,6 +6,6 @@ moduleForComponent('dds/dds-loading-indicator', 'Integration | Component | dds/d
 });
 
 test('it renders', function(assert) {
-  this.render(hbs`{{dds/dds-loading-indicator}}`);
+  this.render(hbs`{{#dds/dds-loading-indicator}}Loading...{{/dds/dds-loading-indicator}}`);
   assert.equal(this.$().text().trim(), 'Loading...');
 });

--- a/tests/integration/components/dds/dds-no-projects-test.js
+++ b/tests/integration/components/dds/dds-no-projects-test.js
@@ -1,0 +1,11 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('dds/dds-no-projects', 'Integration | Component | dds/dds no projects', {
+  integration: true
+});
+
+test('it renders an an alert-danger', function(assert) {
+  this.render(hbs`{{dds/dds-no-projects}}`);
+  assert.notEqual(this.$('.alert.alert-danger').text().trim(), '');
+});

--- a/tests/integration/components/dds/dds-project-files-picker-test.js
+++ b/tests/integration/components/dds/dds-project-files-picker-test.js
@@ -5,7 +5,21 @@ moduleForComponent('dds/dds-project-files-picker', 'Integration | Component | dd
   integration: true
 });
 
-test('it renders two form groups', function(assert) {
-  this.render(hbs`{{dds/dds-project-files-picker}}`);
+test('it renders no form groups when loading', function(assert) {
+  this.set('isLoading', true);
+  this.render(hbs`{{dds/dds-project-files-picker isLoading=isLoading}}`);
+  assert.equal(this.$('.form-group').length, 0);
+});
+
+test('it renders no form groups when empty', function(assert) {
+  this.set('isEmpty', true);
+  this.render(hbs`{{dds/dds-project-files-picker isEmpty=isEmpty}}`);
+  assert.equal(this.$('.form-group').length, 0);
+});
+
+test('it renders two form groups when populated', function(assert) {
+  this.set('isLoading', false);
+  this.set('isEmpty', false);
+  this.render(hbs`{{dds/dds-project-files-picker isLoading=isLoading isEmpty=isEmpty}}`);
   assert.equal(this.$('.form-group').length, 2);
 });

--- a/tests/unit/components/dds/dds-project-files-picker-test.js
+++ b/tests/unit/components/dds/dds-project-files-picker-test.js
@@ -1,0 +1,19 @@
+import { moduleForComponent, test } from 'ember-qunit';
+
+moduleForComponent('dds/dds-project-files-picker', 'Unit | Component | dds/dds project files picker', {
+  unit: true
+});
+
+test('it computes isLoading', function(assert) {
+  let component = this.subject({projects: null});
+  assert.ok(component.get('isLoading'));
+  component.set('projects', [1,2,3]);
+  assert.notOk(component.get('isLoading'));
+});
+
+test('it computes isEmpty', function(assert) {
+  let component = this.subject({projects: []});
+  assert.ok(component.get('isEmpty'));
+  component.set('projects', [1,2,3]);
+  assert.notOk(component.get('isEMpty'));
+});


### PR DESCRIPTION
- While projects are loading, the loading indicator is displayed
- If user has no projects (or has never used DDS), an alert is shown
- Refactors the loading indicator to allow the message to be customized

Fixes #84