### PR TITLE
Shows the current user's email on job summary

### DIFF
--- a/app/components/job-detail-body.js
+++ b/app/components/job-detail-body.js
@@ -3,7 +3,16 @@ import Ember from 'ember';
 const JobDetailBody = Ember.Component.extend({
   tagName: 'div',
   classNames: ['job-detail-body'],
-  job: null
+  job: null,
+  user: Ember.inject.service('user'),
+
+  // Per https://emberigniter.com/render-promise-before-it-resolves/
+  didInsertElement() {
+    this._super(...arguments);
+    this.get('user').currentUser().then(currentUser => {
+      this.set('currentUser', currentUser);
+    });
+  }
 });
 
 JobDetailBody.reopenClass({

--- a/app/templates/components/job-detail-body.hbs
+++ b/app/templates/components/job-detail-body.hbs
@@ -3,14 +3,14 @@
   {{job-authorize job}}
 {{else if job.isAuthorized}}
   <p>You can start the job by clicking <strong>Start</strong>.</p>
-  {{job-oncompletion-detail job.shareGroup}}
+  {{job-oncompletion-detail job.shareGroup currentUser.email}}
   {{job-authorize job}}
 {{else if job.isStarting}}
   <p>Your job has been queued and will begin running once resources are available.</p>
-  {{job-oncompletion-detail job.shareGroup}}
+  {{job-oncompletion-detail job.shareGroup currentUser.email}}
 {{else if job.isRunning}}
   <p>You can cancel the job by clicking <strong>Cancel</strong>.</p>
-  {{job-oncompletion-detail job.shareGroup}}
+  {{job-oncompletion-detail job.shareGroup currentUser.email}}
   {{!-- show details about current state --}}
 {{else if job.isFinished}}
   <p>Your job has completed. Results are available at the location below:</p>

--- a/app/templates/components/job-oncompletion-detail.hbs
+++ b/app/templates/components/job-oncompletion-detail.hbs
@@ -1,3 +1,3 @@
-<p class="body">After the job runs, you will receive an email{{#if email}} at {{email}}{{/if}} with the status of the job.</p>
+<p class="body">After the job runs, you will receive an email{{#if email}} at <strong>{{email}}</strong>{{/if}} with the status of the job.</p>
 <p class="body">Result data will be uploaded to Duke Data Service but will not be available until reviewed by the {{share-group-contact shareGroup}} group.
   If the {{shareGroup.name}} group has any feedback, they will contact you. Otherwise, your results will be delivered as a Duke Data Service project.</p>

--- a/tests/helpers/user-stub.js
+++ b/tests/helpers/user-stub.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export default Ember.Service.extend({
+  user: null,
+  currentUser() {
+    return Ember.RSVP.resolve(this.get('user'));
+  }
+});

--- a/tests/integration/components/job-detail-body-test.js
+++ b/tests/integration/components/job-detail-body-test.js
@@ -1,9 +1,13 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import UserStub from '../../helpers/user-stub';
 
 moduleForComponent('job-detail-body', 'Integration | Component | job detail body', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    this.register('service:user', UserStub);
+  }
 });
 
 test('it renders', function(assert) {

--- a/tests/integration/components/job-detail-test.js
+++ b/tests/integration/components/job-detail-test.js
@@ -1,8 +1,12 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import UserStub from '../../helpers/user-stub';
 
 moduleForComponent('job-detail', 'Integration | Component | job detail', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    this.register('service:user', UserStub);
+  }
 });
 
 test('it renders', function(assert) {

--- a/tests/integration/components/job-summary-test.js
+++ b/tests/integration/components/job-summary-test.js
@@ -1,9 +1,13 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import UserStub from '../../helpers/user-stub';
 
 moduleForComponent('job-summary', 'Integration | Component | job summary', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    this.register('service:user', UserStub);
+  }
 });
 
 test('it renders summary heading', function(assert) {

--- a/tests/unit/components/job-detail-body-test.js
+++ b/tests/unit/components/job-detail-body-test.js
@@ -1,0 +1,26 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
+import BaseUserStub from '../../helpers/user-stub'
+
+const mockUser = Ember.Object.create({
+  id: 3,
+  username: 'link'
+});
+
+const UserStub = BaseUserStub.extend({
+  user: mockUser
+});
+
+moduleForComponent('job-detail-body', 'Unit | Component | job detail body', {
+  unit: true,
+  beforeEach() {
+    this.register('service:user', UserStub);
+  }
+});
+
+test('it resolves currentUser() from user service', function(assert) {
+  const job = Ember.Object.create({});
+  let component = this.subject({job: job});
+  this.render();
+  assert.equal(component.get('currentUser'), mockUser);
+});


### PR DESCRIPTION
Fills in user email address into job-oncompletion-detail that would
render it if provided

Fixes #72