### PR TITLE
Allow job deletion

### DIFF
--- a/app/components/job-detail-row.js
+++ b/app/components/job-detail-row.js
@@ -7,8 +7,13 @@ const JobDetailRow = Ember.Component.extend({
     delete() {
       this.get('job').destroyRecord();
     }
-  }
-
+  },
+  modalConfirmationTitle: Ember.computed('job.id', function() {
+    return `Are you sure you want to delete job ${this.get('job.id')}?`;
+  }),
+  modalConfirmationBody: Ember.computed('job.name', function() {
+    return `Your Bespin job '${this.get('job.name')}' will be deleted permanently. This action cannot be undone.`
+  })
 });
 
 JobDetailRow.reopenClass({

--- a/app/components/job-detail-row.js
+++ b/app/components/job-detail-row.js
@@ -2,7 +2,13 @@ import Ember from 'ember';
 
 const JobDetailRow = Ember.Component.extend({
   tagName: 'tr',
-  classNames: ['job-detail-row']
+  classNames: ['job-detail-row'],
+  actions: {
+    delete() {
+      this.get('job').destroyRecord();
+    }
+  }
+
 });
 
 JobDetailRow.reopenClass({

--- a/app/components/modal-confirmation.js
+++ b/app/components/modal-confirmation.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  onConfirm: () => {},
+  title: 'Confirm',
+  openButtonTitle: 'Open',
+  body: 'Please confirm the action.',
+  confirmButtonTitle: 'Confirm',
+  modalConfirmationOpen: false,
+  openButtonType: 'danger',
+  confirmButtonType: 'danger',
+  actions: {
+    confirm() {
+      this.get('onConfirm')();
+      this.set('modalConfirmationOpen', false);
+    }
+  }
+});
+

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -44,6 +44,10 @@ export default DS.Model.extend({
   isCanceled: Ember.computed('state', function() {
     return this.get('state') === 'C';
   }),
+  isDeletable: Ember.computed('state', function() {
+    const deletableStates = ['N','A','F','E','C'];
+    return deletableStates.includes(this.get('state'));
+  }),
   outputProject: DS.belongsTo('job-dds-output-project'),
   // Named jobErrors because DS.Model already has an errors property (contains validation error messages)
   jobErrors: DS.hasMany('job-error'),

--- a/app/templates/components/job-detail-row.hbs
+++ b/app/templates/components/job-detail-row.hbs
@@ -6,4 +6,7 @@
 <td class="job-detail-cell-created">{{job.created}}</td>
 <td class="job-detail-cell-updated">{{job.lastUpdated}}</td>
 <td class="job-detail-cell-readme">{{#if job.isFinished}}{{#link-to "jobs.readme" job.outputProject}}README{{/link-to}}{{/if}}</td>
+<td class="job-detail-cell-delete">{{#if job.isDeletable}}
+  {{#bs-button size='sm' type='danger' title='Delete' onClick=(action 'delete')}}Delete{{/bs-button}}{{/if}}
+</td>
 {{yield}}

--- a/app/templates/components/job-detail-row.hbs
+++ b/app/templates/components/job-detail-row.hbs
@@ -7,6 +7,12 @@
 <td class="job-detail-cell-updated">{{job.lastUpdated}}</td>
 <td class="job-detail-cell-readme">{{#if job.isFinished}}{{#link-to "jobs.readme" job.outputProject}}README{{/link-to}}{{/if}}</td>
 <td class="job-detail-cell-delete">{{#if job.isDeletable}}
-  {{#bs-button size='sm' type='danger' title='Delete' onClick=(action 'delete')}}Delete{{/bs-button}}{{/if}}
+  {{modal-confirmation
+    title=modalConfirmationTitle
+    body=modalConfirmationBody
+    openButtonTitle='Delete'
+    confirmButtonTitle='Delete'
+    onConfirm=(action 'delete')}}
+{{/if}}
 </td>
 {{yield}}

--- a/app/templates/components/job-header-row.hbs
+++ b/app/templates/components/job-header-row.hbs
@@ -6,4 +6,5 @@
 <th class="job-table-header-created">Created</th>
 <th class="job-table-header-updated">Updated</th>
 <th class="job-table-header-readme">Details</th>
+<th class="job-table-header-delete">Delete</th>
 {{yield}}

--- a/app/templates/components/modal-confirmation.hbs
+++ b/app/templates/components/modal-confirmation.hbs
@@ -10,8 +10,11 @@
     {{body}}
   {{/modal.body}}
   {{#modal.footer}}
-    {{#bs-button onClick=(action modal.close)}}Cancel{{/bs-button}}
-    {{#bs-button type=confirmButtonType onClick=(action 'confirm')}}{{confirmButtonTitle}}{{/bs-button}}
+    {{#bs-button class='modal-confirmation-cancel'
+      onClick=(action modal.close)}}Cancel{{/bs-button}}
+    {{#bs-button class='modal-confirmation-confirm'
+                 type=confirmButtonType
+                 onClick=(action 'confirm')}}{{confirmButtonTitle}}{{/bs-button}}
   {{/modal.footer}}
 {{/bs-modal}}
 {{#bs-button

--- a/app/templates/components/modal-confirmation.hbs
+++ b/app/templates/components/modal-confirmation.hbs
@@ -16,6 +16,7 @@
 {{/bs-modal}}
 {{#bs-button
   size='sm'
+  class='modal-confirmation-open'
   type=openButtonType
   onClick=(action (mut modalConfirmationOpen) true)}}
   {{openButtonTitle}}

--- a/app/templates/components/modal-confirmation.hbs
+++ b/app/templates/components/modal-confirmation.hbs
@@ -1,0 +1,22 @@
+{{#bs-modal
+  open=modalConfirmationOpen
+  onSubmit=(action 'confirm')
+  onHidden=(action (mut modalConfirmationOpen) false)
+  as |modal|}}
+  {{#modal.header}}
+    <h4 class="modal-title">{{title}}</h4>
+  {{/modal.header}}
+  {{#modal.body}}
+    {{body}}
+  {{/modal.body}}
+  {{#modal.footer}}
+    {{#bs-button onClick=(action modal.close)}}Cancel{{/bs-button}}
+    {{#bs-button type=confirmButtonType onClick=(action 'confirm')}}{{confirmButtonTitle}}{{/bs-button}}
+  {{/modal.footer}}
+{{/bs-modal}}
+{{#bs-button
+  size='sm'
+  type=openButtonType
+  onClick=(action (mut modalConfirmationOpen) true)}}
+  {{openButtonTitle}}
+{{/bs-button}}

--- a/tests/integration/components/job-detail-row-test.js
+++ b/tests/integration/components/job-detail-row-test.js
@@ -29,3 +29,14 @@ test('it hides readme link for finished jobs', function(assert) {
   this.render(hbs`{{job-detail-row job}}`);
   assert.equal(this.$('.job-detail-cell-readme a').text().trim(), '', 'Should not show readme link for unfinished job');
 });
+
+test('it renders a modal confirmation button for deletable jobs', function(assert) {
+  this.set('job', {isDeletable: false});
+  this.render(hbs`{{job-detail-row job}}`);
+  assert.equal(this.$('.job-detail-cell-delete button.modal-confirmation-open').length, 0);
+
+  this.set('job', {isDeletable: true});
+  this.render(hbs`{{job-detail-row job}}`);
+  assert.equal(this.$('.job-detail-cell-delete button.modal-confirmation-open').length, 1);
+
+});

--- a/tests/integration/components/job-header-row-test.js
+++ b/tests/integration/components/job-header-row-test.js
@@ -7,5 +7,5 @@ moduleForComponent('job-header-row', 'Integration | Component | job header row',
 
 test('it renders', function(assert) {
   this.render(hbs`{{job-header-row}}`);
-  assert.equal(this.$('th').length, 8);
+  assert.equal(this.$('th').length, 9);
 });

--- a/tests/integration/components/modal-confirmation-test.js
+++ b/tests/integration/components/modal-confirmation-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('modal-confirmation', 'Integration | Component | modal confirmation', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{modal-confirmation}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#modal-confirmation}}
+      template block text
+    {{/modal-confirmation}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/modal-confirmation-test.js
+++ b/tests/integration/components/modal-confirmation-test.js
@@ -12,14 +12,5 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{modal-confirmation}}`);
 
-  assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#modal-confirmation}}
-      template block text
-    {{/modal-confirmation}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.notEqual(this.$().text().trim(), '');
 });

--- a/tests/integration/components/modal-confirmation-test.js
+++ b/tests/integration/components/modal-confirmation-test.js
@@ -10,7 +10,36 @@ test('it renders', function(assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.render(hbs`{{modal-confirmation}}`);
+  this.set('title', 'Modal Title');
+  this.set('openButtonTitle', 'Show');
+  this.set('body', 'Modal Body');
+  this.set('confirmButtonTitle', 'Delete');
 
-  assert.notEqual(this.$().text().trim(), '');
+  this.render(hbs`{{modal-confirmation
+    title=title
+    openButtonTitle=openButtonTitle
+    body=body
+    confirmButtonTitle=confirmButtonTitle
+  }}`);
+
+  assert.equal(this.$('.modal-title').text().trim(), 'Modal Title');
+  assert.equal(this.$('.modal-body').text().trim(), 'Modal Body');
+  assert.equal(this.$('button.modal-confirmation-open').text().trim(), 'Show');
+  assert.equal(this.$('button.modal-confirmation-confirm').text().trim(), 'Delete');
+});
+
+test('Clicking the open button shows the modal', function(assert) {
+  this.render(hbs`{{modal-confirmation}}`);
+  // We test that the modal is shown by the modal-backdrop class over the rest of the component
+  assert.equal(this.$('.modal-backdrop').length, 0);
+  this.$('button.modal-confirmation-open').click();
+  assert.equal(this.$('.modal-backdrop').length, 1);
+});
+
+test('Clicking the confirm button calls the onConfirm', function(assert) {
+  this.set('onConfirm', () => {
+    assert.ok(true);
+  });
+  this.render(hbs`{{modal-confirmation onConfirm=onConfirm}}`);
+  this.$('button.modal-confirmation-confirm').click();
 });

--- a/tests/unit/components/job-detail-row-test.js
+++ b/tests/unit/components/job-detail-row-test.js
@@ -1,0 +1,17 @@
+import { moduleForComponent, test } from 'ember-qunit';
+
+moduleForComponent('job-detail-row', 'Unit | Component | job detail row', {
+  // Specify the other units that are required for this test
+  needs: ['component:job-detail-row', 'helper:decode-job-state'],
+  unit: true
+});
+
+test('it computes modalConfimrationTitle from job id', function(assert) {
+  const jobDetailRow = this.subject({job: {id: 47}});
+  assert.equal(jobDetailRow.get('modalConfirmationTitle'), 'Are you sure you want to delete job 47?');
+});
+
+test('it computes modalConfirmationBody from job name', function(assert) {
+  const jobDetailRow = this.subject({job: {name: 'Wind up'}});
+  assert.equal(jobDetailRow.get('modalConfirmationBody'), "Your Bespin job 'Wind up' will be deleted permanently. This action cannot be undone.");
+});

--- a/tests/unit/models/job-test.js
+++ b/tests/unit/models/job-test.js
@@ -169,3 +169,31 @@ test('it computes lastJobError by most recently created', function(assert) {
     assert.equal(job.get('lastJobError.id'), 'newest');
   });
 });
+
+test('it computes isDeletable', function(assert) {
+  const statesAndDeletable = [
+    ['N', true],
+    ['A', true],
+    ['S', false],
+    ['r', false],
+    ['R', false],
+    ['F', true],
+    ['E', true],
+    ['c', false],
+    ['C', true],
+  ];
+  assert.expect(statesAndDeletable.length);
+  let job = this.subject();
+  Ember.run(() => {
+    statesAndDeletable.forEach(function (stateAndDeletable) {
+      const state = stateAndDeletable[0];
+      const deletable = stateAndDeletable[1];
+      job.set('state', state);
+      if (deletable) {
+        assert.ok(job.get('isDeletable'), `Job in state ${state} should be deletable`);
+      } else {
+        assert.notOk(job.get('isDeletable'), `Job in state ${state} should not be deletable`);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Basic UI for deleting jobs:

- Adds a delete button to the job listing for jobs that are not currently running or transitioning.
- Prompts for confirmation before deleting jobs
- On deletion, calls `job.destroyRecord()`, which sends a `DELETE` request to `/api/jobs/:id` (https://github.com/Duke-GCB/bespin-api/pull/103)

Fixes #91 