### PR TITLE
Support for NamedFASTQFilePairType, check samples before creating job 

### DIFF
--- a/app/components/questionnaire/answer-form-list.js
+++ b/app/components/questionnaire/answer-form-list.js
@@ -4,6 +4,7 @@ import ComponentSettings from 'bespin-ui/utils/component-settings';
 const AnswerFormList = Ember.Component.extend({
   classNames: ['answer-form-list'],
   answerSet: null,
+  answerFormErrors: null, // Client-side validation errors, passed down to each component
   fields: Ember.computed('answerSet.questionnaire.userFieldsJson.@each', function() {
     const userFields = this.get('answerSet.questionnaire.userFieldsJson') || [];
     const fieldsToComponents = userFields.map(field => {
@@ -22,7 +23,6 @@ const AnswerFormList = Ember.Component.extend({
     // Strip out any fields for which we don't have a component
     return fieldsToComponents.compact();
   }),
-
   /**
    * Look up the component name to use to render a form field for the given CWL type
    * May return null
@@ -68,7 +68,7 @@ const AnswerFormList = Ember.Component.extend({
 });
 
 AnswerFormList.reopenClass({
-  positionalParams: ['answerSet']
+  positionalParams: ['answerSet', 'answerFormErrors']
 });
 
 export default AnswerFormList;

--- a/app/components/questionnaire/answer-form.js
+++ b/app/components/questionnaire/answer-form.js
@@ -1,11 +1,12 @@
 import Ember from 'ember';
 
 const AnswerForm = Ember.Component.extend({
+  answerFormErrors: null,
   classNames: ['container']
 });
 
 AnswerForm.reopenClass({
-  positionalParams: ['answerSet']
+  positionalParams: ['answerSet', 'answerFormErrors']
 });
 
 export default AnswerForm;

--- a/app/components/questionnaire/fastq-file-pair-list.js
+++ b/app/components/questionnaire/fastq-file-pair-list.js
@@ -18,11 +18,15 @@ const FASTQFilePairList = FileGroupList.extend({
     const fieldName = this.get('fieldName');
     const pairCount = this.get('fastqFilePairs.length');
     if(pairCount < 1) {
-      answerFormErrors.setError(fieldName, 'Please choose at least 1 sample pair');
+      answerFormErrors.setError(fieldName, 'Please choose at least 1 sample pair.');
     } else if(!this.get('fileItems.isComplete')) {
-      answerFormErrors.setError(fieldName, 'Please ensure all samples are paired')
+      answerFormErrors.setError(fieldName, 'Please ensure all samples are paired.')
     } else if(!this.get('fileItems.hasUniqueSampleNames')) {
-      answerFormErrors.setError(fieldName, 'Please ensure all pairs chosen have unique names')
+      answerFormErrors.setError(fieldName, 'Please ensure all pairs chosen have unique names.')
+    } else if(this.get('fileItems.hasUnnamedSamples')) {
+      answerFormErrors.setError(fieldName, 'Unable to determine sample names for all pairs. ' +
+        'Please ensure both files in a pair have a common name prefix (e.g. AB1234_R1.fastq.gz, AB1234_R2.fastq.gz. ' +
+        'You may need to rename your files.');
     } else {
       // All Good!
       answerFormErrors.clearError(fieldName);

--- a/app/components/questionnaire/fastq-file-pair-list.js
+++ b/app/components/questionnaire/fastq-file-pair-list.js
@@ -25,7 +25,7 @@ const FASTQFilePairList = FileGroupList.extend({
       answerFormErrors.setError(fieldName, 'Please ensure all pairs chosen have unique names.')
     } else if(this.get('fileItems.hasUnnamedSamples')) {
       answerFormErrors.setError(fieldName, 'Unable to determine sample names for all pairs. ' +
-        'Please ensure both files in a pair have a common name prefix (e.g. AB1234_R1.fastq.gz, AB1234_R2.fastq.gz. ' +
+        'Please ensure both files in a pair have the same name before any underscore, hyphen, or space (e.g. AB1234_R1.fastq.gz, AB1234_R2.fastq.gz. ' +
         'You may need to rename your files.');
     } else {
       // All Good!

--- a/app/components/questionnaire/fastq-file-pair-list.js
+++ b/app/components/questionnaire/fastq-file-pair-list.js
@@ -6,21 +6,16 @@ const FASTQFilePairList = FileGroupList.extend({
   groupSize: 2,
   answerFormErrors: null,
   fieldErrors: Ember.computed('answerFormErrors.[]', 'fieldName', function() {
-    Ember.Logger.log('field errors!');
     return this.get('answerFormErrors').get('errors').filterBy('field', this.get('fieldName'));
   }),
   fastqFilePairs: Ember.computed.alias('fileItems.fastqFilePairs'),
-  validityDidChange: Ember.on('init', Ember.observer('fastqFilePairs.length','fastqFilePairs.isComplete', function() {
-    Ember.Logger.log('validity did change!');
+  validityDidChange: Ember.on('init', Ember.observer('fastqFilePairs.length','fileItems.isComplete', function() {
     const answerFormErrors = this.get('answerFormErrors');
     const fieldName = this.get('fieldName');
     const pairCount = this.get('fastqFilePairs.length');
     if(pairCount < 1) {
-      Ember.Logger.log('less than one pair');
       answerFormErrors.setError(fieldName, 'Please choose at least 1 sample pair');
-    } else if(!this.get('fastqFilePairs.isComplete')) {
-      // This test is failing
-      Ember.Logger.log('things are not full');
+    } else if(!this.get('fileItems.isComplete')) {
       answerFormErrors.setError(fieldName, 'Please ensure all samples are paired')
     } else {
       // TODO: Check uniqueness

--- a/app/components/questionnaire/fastq-file-pair-list.js
+++ b/app/components/questionnaire/fastq-file-pair-list.js
@@ -21,8 +21,10 @@ const FASTQFilePairList = FileGroupList.extend({
       answerFormErrors.setError(fieldName, 'Please choose at least 1 sample pair');
     } else if(!this.get('fileItems.isComplete')) {
       answerFormErrors.setError(fieldName, 'Please ensure all samples are paired')
+    } else if(!this.get('fileItems.hasUniqueSampleNames')) {
+      answerFormErrors.setError(fieldName, 'Please ensure all pairs chosen have unique names')
     } else {
-      // TODO: Check uniqueness
+      // All Good!
       answerFormErrors.clearError(fieldName);
     }
   })),

--- a/app/components/questionnaire/fastq-file-pair-list.js
+++ b/app/components/questionnaire/fastq-file-pair-list.js
@@ -5,8 +5,8 @@ import { FASTQFileItemList }from 'bespin-ui/utils/fastq-file-item-list';
 const FASTQFilePairList = FileGroupList.extend({
   groupSize: 2,
   answerFormErrors: null,
-  fieldErrors: Ember.computed('answerFormErrors.[]', 'fieldName', function() {
-    return this.get('answerFormErrors').get('errors').filterBy('field', this.get('fieldName'));
+  fieldErrors: Ember.computed('answerFormErrors.errors.[]', 'fieldName', function() {
+    return this.get('answerFormErrors.errors').filterBy('field', this.get('fieldName'));
   }),
   fastqFilePairs: Ember.computed.alias('fileItems.fastqFilePairs'),
   validityDidChange: Ember.on('init', Ember.observer('answerFormErrors', 'fastqFilePairs.length','fileItems.isComplete', function() {

--- a/app/components/questionnaire/fastq-file-pair-list.js
+++ b/app/components/questionnaire/fastq-file-pair-list.js
@@ -1,0 +1,55 @@
+import Ember from 'ember';
+import FileGroupList from 'bespin-ui/components/questionnaire/file-group-list';
+import { FileItemList, FileItem } from 'bespin-ui/utils/file-item-list';
+
+// The internal data structure
+const FASTQFileItemList = FileItemList.extend({
+  groupSize: 2,
+
+  // must compute sample names somehow. override FileItemGroups
+
+  // What are the jobs of this component
+  // cwlObjectValue needs to return the new structure
+  // in the component, groups is computed from fileItems.fileItemGroups and just pulls out the ddsfile
+  cwlObjectValue: Ember.computed('fileItemGroups.[]', function() {
+    const fileItemGroups = this.get('fileItemGroups');
+    return fileItemGroups.map(function (fileItemGroup) {
+      return Ember.Object.create({
+        name: 'Fixme cwl object',
+        file1: fileItemGroup.objectAt(0).get('cwlObject'),
+        file2: fileItemGroup.objectAt(1).get('cwlObject')
+      });
+    });
+  })
+});
+
+// The component
+const FASTQFilePairList = FileGroupList.extend({
+  groupSize: 2,
+
+  groups: Ember.computed.map('fileItems.fileItemGroups', function(fileItemGroup) {
+    const group = Ember.Object.create({
+      name: 'fixme-group'
+    });
+
+    // Check array size before accessing
+    if(fileItemGroup.get('length') > 0) {
+      group.set('file1',fileItemGroup.objectAt(0).get('ddsFile'));
+    }
+
+    if(fileItemGroup.get('length') > 1) {
+      group.set('file2',fileItemGroup.objectAt(1).get('ddsFile'));
+    }
+    return group;
+  }),
+
+  // Override init to user our customized FileItemList
+  init() {
+    this._super(...arguments);
+    if(Ember.isEmpty(this.get('fileItems'))) {
+      this.set('fileItems', FileItemList.create());
+    }
+  }
+});
+
+export default FASTQFilePairList;

--- a/app/components/questionnaire/fastq-file-pair-list.js
+++ b/app/components/questionnaire/fastq-file-pair-list.js
@@ -9,8 +9,12 @@ const FASTQFilePairList = FileGroupList.extend({
     return this.get('answerFormErrors').get('errors').filterBy('field', this.get('fieldName'));
   }),
   fastqFilePairs: Ember.computed.alias('fileItems.fastqFilePairs'),
-  validityDidChange: Ember.on('init', Ember.observer('fastqFilePairs.length','fileItems.isComplete', function() {
+  validityDidChange: Ember.on('init', Ember.observer('answerFormErrors', 'fastqFilePairs.length','fileItems.isComplete', function() {
     const answerFormErrors = this.get('answerFormErrors');
+    if(!answerFormErrors) {
+      // We have not answerFormErrors object, bail out
+      return;
+    }
     const fieldName = this.get('fieldName');
     const pairCount = this.get('fastqFilePairs.length');
     if(pairCount < 1) {

--- a/app/components/questionnaire/fastq-file-pair-list.js
+++ b/app/components/questionnaire/fastq-file-pair-list.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import FileGroupList from 'bespin-ui/components/questionnaire/file-group-list';
-import FASTQFileItemList from 'bespin-ui/utils/fastq-file-item-list';
+import { FASTQFileItemList }from 'bespin-ui/utils/fastq-file-item-list';
 
 const FASTQFilePairList = FileGroupList.extend({
   groupSize: 2,

--- a/app/components/questionnaire/fastq-file-pair-list.js
+++ b/app/components/questionnaire/fastq-file-pair-list.js
@@ -7,10 +7,11 @@ const FASTQFilePairList = FileGroupList.extend({
   fastqFilePairs: Ember.computed.alias('fileItems.fastqFilePairs'),
   // Override init to user our customized FileItemList type
   init() {
-    this._super(...arguments);
     if(Ember.isEmpty(this.get('fileItems'))) {
       this.set('fileItems', FASTQFileItemList.create());
     }
+    // Call this._super AFTER setting fileItems. Otherwise the base class sets it
+    return this._super(...arguments);
   },
   actions: {
     click() {

--- a/app/components/questionnaire/fastq-file-pair-list.js
+++ b/app/components/questionnaire/fastq-file-pair-list.js
@@ -4,7 +4,30 @@ import { FASTQFileItemList }from 'bespin-ui/utils/fastq-file-item-list';
 
 const FASTQFilePairList = FileGroupList.extend({
   groupSize: 2,
+  answerFormErrors: null,
+  fieldErrors: Ember.computed('answerFormErrors.[]', 'fieldName', function() {
+    Ember.Logger.log('field errors!');
+    return this.get('answerFormErrors').get('errors').filterBy('field', this.get('fieldName'));
+  }),
   fastqFilePairs: Ember.computed.alias('fileItems.fastqFilePairs'),
+  validityDidChange: Ember.on('init', Ember.observer('fastqFilePairs.length','fastqFilePairs.isComplete', function() {
+    Ember.Logger.log('validity did change!');
+    const answerFormErrors = this.get('answerFormErrors');
+    const fieldName = this.get('fieldName');
+    const pairCount = this.get('fastqFilePairs.length');
+    if(pairCount < 1) {
+      Ember.Logger.log('less than one pair');
+      answerFormErrors.setError(fieldName, 'Please choose at least 1 sample pair');
+    } else if(!this.get('fastqFilePairs.isComplete')) {
+      // This test is failing
+      Ember.Logger.log('things are not full');
+      answerFormErrors.setError(fieldName, 'Please ensure all samples are paired')
+    } else {
+      // TODO: Check uniqueness
+      answerFormErrors.clearError(fieldName);
+    }
+  })),
+
   // Override init to user our customized FileItemList type
   init() {
     if(Ember.isEmpty(this.get('fileItems'))) {

--- a/app/components/questionnaire/fastq-file-pair-list.js
+++ b/app/components/questionnaire/fastq-file-pair-list.js
@@ -12,13 +12,7 @@ const FASTQFilePairList = FileGroupList.extend({
     }
     // Call this._super AFTER setting fileItems. Otherwise the base class sets it
     return this._super(...arguments);
-  },
-  actions: {
-    click() {
-      Ember.Logger.log(JSON.stringify(this.get('fileItems.cwlObjectValue'), null, 2));
-    }
   }
-
 });
 
 export default FASTQFilePairList;

--- a/app/components/questionnaire/fastq-file-pair-list.js
+++ b/app/components/questionnaire/fastq-file-pair-list.js
@@ -1,55 +1,23 @@
 import Ember from 'ember';
 import FileGroupList from 'bespin-ui/components/questionnaire/file-group-list';
-import { FileItemList, FileItem } from 'bespin-ui/utils/file-item-list';
+import FASTQFileItemList from 'bespin-ui/utils/fastq-file-item-list';
 
-// The internal data structure
-const FASTQFileItemList = FileItemList.extend({
-  groupSize: 2,
-
-  // must compute sample names somehow. override FileItemGroups
-
-  // What are the jobs of this component
-  // cwlObjectValue needs to return the new structure
-  // in the component, groups is computed from fileItems.fileItemGroups and just pulls out the ddsfile
-  cwlObjectValue: Ember.computed('fileItemGroups.[]', function() {
-    const fileItemGroups = this.get('fileItemGroups');
-    return fileItemGroups.map(function (fileItemGroup) {
-      return Ember.Object.create({
-        name: 'Fixme cwl object',
-        file1: fileItemGroup.objectAt(0).get('cwlObject'),
-        file2: fileItemGroup.objectAt(1).get('cwlObject')
-      });
-    });
-  })
-});
-
-// The component
 const FASTQFilePairList = FileGroupList.extend({
   groupSize: 2,
-
-  groups: Ember.computed.map('fileItems.fileItemGroups', function(fileItemGroup) {
-    const group = Ember.Object.create({
-      name: 'fixme-group'
-    });
-
-    // Check array size before accessing
-    if(fileItemGroup.get('length') > 0) {
-      group.set('file1',fileItemGroup.objectAt(0).get('ddsFile'));
-    }
-
-    if(fileItemGroup.get('length') > 1) {
-      group.set('file2',fileItemGroup.objectAt(1).get('ddsFile'));
-    }
-    return group;
-  }),
-
-  // Override init to user our customized FileItemList
+  fastqFilePairs: Ember.computed.alias('fileItems.fastqFilePairs'),
+  // Override init to user our customized FileItemList type
   init() {
     this._super(...arguments);
     if(Ember.isEmpty(this.get('fileItems'))) {
-      this.set('fileItems', FileItemList.create());
+      this.set('fileItems', FASTQFileItemList.create());
+    }
+  },
+  actions: {
+    click() {
+      Ember.Logger.log(JSON.stringify(this.get('fileItems.cwlObjectValue'), null, 2));
     }
   }
+
 });
 
 export default FASTQFilePairList;

--- a/app/components/questionnaire/fastq-file-pair-row.js
+++ b/app/components/questionnaire/fastq-file-pair-row.js
@@ -1,6 +1,12 @@
 import Ember from 'ember';
 import FileGroupRow from 'bespin-ui/components/questionnaire/file-group-row';
 
-export default FileGroupRow.extend({
-  groupName: Ember.computed.alias('group.name'),
+const FASTQFilePairRow = FileGroupRow.extend({
+  pairName: Ember.computed.alias('pair.name'),
 });
+
+FASTQFilePairRow.reopenClass({
+  positionalParams: ['pair', 'groupIndex', 'onClick']
+});
+
+export default FASTQFilePairRow;

--- a/app/components/questionnaire/fastq-file-pair-row.js
+++ b/app/components/questionnaire/fastq-file-pair-row.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import FileGroupRow from 'bespin-ui/components/questionnaire/file-group-row';
+
+export default FileGroupRow.extend({
+  groupName: Ember.computed.alias('group.name'),
+});

--- a/app/components/questionnaire/fastq-file-pair-row.js
+++ b/app/components/questionnaire/fastq-file-pair-row.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import FileGroupRow from 'bespin-ui/components/questionnaire/file-group-row';
 
 const FASTQFilePairRow = FileGroupRow.extend({
+  classNames: ['fastq-file-pair-row', 'well','well-sm'],
   pairName: Ember.computed.oneWay('pair.name'),
   errors: Ember.computed('pair.file1', 'pair.file2', 'pair.name', function() {
     const errors = [];

--- a/app/components/questionnaire/fastq-file-pair-row.js
+++ b/app/components/questionnaire/fastq-file-pair-row.js
@@ -2,7 +2,25 @@ import Ember from 'ember';
 import FileGroupRow from 'bespin-ui/components/questionnaire/file-group-row';
 
 const FASTQFilePairRow = FileGroupRow.extend({
-  pairName: Ember.computed.alias('pair.name'),
+  pairName: Ember.computed.oneWay('pair.name'),
+  errors: Ember.computed('pair.file1', 'pair.file2', 'pair.name', function() {
+    const errors = [];
+    const file1 = this.get('pair.file1');
+    const file2 = this.get('pair.file2');
+    const name = this.get('pair.name');
+    let message = '';
+    // If no files are chosen, indicate this is automatic
+    if(Ember.isEmpty(file1) || Ember.isEmpty(file2)) {
+      message = 'Select two files to detect sample name.';
+    } else if(Ember.isEmpty(name)) {
+      // If files are chosen, indicate the automatic naming failed
+      message = 'No sample name detected. File names must begin with a common name to detect sample name.';
+    }
+    if(message) {
+      errors.addObject(Ember.Object.create({message: message}));
+    }
+    return errors;
+  })
 });
 
 FASTQFilePairRow.reopenClass({

--- a/app/components/questionnaire/file-group-file.js
+++ b/app/components/questionnaire/file-group-file.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 const FileGroupFile = Ember.Component.extend({
-  file: null,
+  file: null, // A dds-resource
   tagName: 'li',
   classNames: ['file-group-file'],
   index: 0,

--- a/app/controllers/jobs/new/build-answer-set.js
+++ b/app/controllers/jobs/new/build-answer-set.js
@@ -35,8 +35,8 @@ export default Ember.Controller.extend({
       // First check if there are any form field errors
       const fieldErrorLength = this.get('answerFormErrors.length');
       if(fieldErrorLength > 0) {
-        Ember.Logger.log('setting errors show to true');
         this.set('answerFormErrors.show', true);
+        // When errors, stop here and do not save anything
         return;
       } else {
         this.set('answerFormErrors.show', false);

--- a/app/controllers/jobs/new/build-answer-set.js
+++ b/app/controllers/jobs/new/build-answer-set.js
@@ -1,12 +1,47 @@
 import Ember from 'ember';
 
+const AnswerFormFieldErrors = Ember.Object.extend({
+  errors: null,
+  show: false,
+  length: Ember.computed.oneWay('errors.length'),
+  init() {
+    this.set('errors', []);
+  },
+  setError(fieldName, message) {
+    this.clearError(fieldName);
+    this.get('errors').addObject({field: fieldName, message: message});
+  },
+  clearError(fieldName) {
+    const error = this.get('errors').findBy('field', fieldName);
+    this.get('errors').removeObject(error);
+  },
+});
+
 export default Ember.Controller.extend({
+  // answerFormFieldErrors is an object owned by the controller, but passed down to individual answer-form
+  // components to report their field errors
+  answerFormErrors: null,
+  init() {
+    this._super(...arguments);
+    this.set('answerFormErrors', AnswerFormFieldErrors.create());
+  },
+
   actions: {
     back() {
       let workflowVersionId = this.get('model.questionnaire.workflowVersion.id');
       this.transitionToRoute('jobs.new.select-questionnaire', workflowVersionId);
     },
     saveAndCreateJob() {
+      // First check if there are any form field errors
+      const fieldErrorLength = this.get('answerFormErrors.length');
+      if(fieldErrorLength > 0) {
+        Ember.Logger.log('setting errors show to true');
+        this.set('answerFormErrors.show', true);
+        return;
+      } else {
+        this.set('answerFormErrors.show', false);
+      }
+
       // Must save all the things that compose an answer set
       let answerSet = this.get('model');
       // To call save on the related model, we must resolve it as a promise

--- a/app/controllers/jobs/new/build-answer-set.js
+++ b/app/controllers/jobs/new/build-answer-set.js
@@ -12,6 +12,7 @@ const AnswerFormFieldErrors = Ember.Object.extend({
     this.get('errors').addObject({field: fieldName, message: message});
   },
   clearError(fieldName) {
+    this.set('show', false);
     const error = this.get('errors').findBy('field', fieldName);
     this.get('errors').removeObject(error);
   },

--- a/app/templates/components/questionnaire/answer-form-list.hbs
+++ b/app/templates/components/questionnaire/answer-form-list.hbs
@@ -1,4 +1,9 @@
 {{#each fields as |field|}}
-  {{component field.componentName field.name (action 'answerChanged') formatSettings=field.formatSettings}}
+  {{component field.componentName
+              field.name
+              (action 'answerChanged')
+              formatSettings=field.formatSettings
+              answerFormErrors=answerFormErrors
+  }}
 {{/each}}
 {{yield}}

--- a/app/templates/components/questionnaire/answer-form.hbs
+++ b/app/templates/components/questionnaire/answer-form.hbs
@@ -1,5 +1,5 @@
 {{questionnaire/answer-form-header answerSet.questionnaire}}
 {{questionnaire/job-name answerSet}}
 {{questionnaire/fund-code answerSet}}
-{{questionnaire/answer-form-list answerSet}}
+{{questionnaire/answer-form-list answerSet answerFormErrors}}
 {{yield}}

--- a/app/templates/components/questionnaire/fastq-file-pair-list.hbs
+++ b/app/templates/components/questionnaire/fastq-file-pair-list.hbs
@@ -10,7 +10,6 @@
     {{questionnaire/empty-selection}}
   {{/each}}
   {{#if answerFormErrors.show}}
-    Help. Errors are not automatically updating
     {{error-panel errors=fieldErrors}}
   {{/if}}
 </div>

--- a/app/templates/components/questionnaire/fastq-file-pair-list.hbs
+++ b/app/templates/components/questionnaire/fastq-file-pair-list.hbs
@@ -9,5 +9,9 @@
   {{else}}
     {{questionnaire/empty-selection}}
   {{/each}}
+  {{#if answerFormErrors.show}}
+    Help. Errors are not automatically updating
+    {{error-panel errors=fieldErrors}}
+  {{/if}}
 </div>
 {{yield}}

--- a/app/templates/components/questionnaire/fastq-file-pair-list.hbs
+++ b/app/templates/components/questionnaire/fastq-file-pair-list.hbs
@@ -1,0 +1,13 @@
+<div class="col-md-6 file-group-list-picker">
+  <label>Pick your {{ groupTitle }} {{ groupSizeName }} from Duke Data Service</label>
+  {{dds/dds-project-files-picker projects selectedDdsFiles (action 'addFile') formatSettings=formatSettings}}
+</div>
+<div class="col-md-6 file-group-list-selections">
+  <label>Selected {{ groupTitle }} {{ groupSizeName }}</label>
+  {{#each groups as |pair pairIndex|}}
+    {{questionnaire/fastq-file-pair-row pair pairIndex (action 'removeAt')}}
+  {{else}}
+    {{questionnaire/empty-selection}}
+  {{/each}}
+</div>
+{{yield}}

--- a/app/templates/components/questionnaire/fastq-file-pair-list.hbs
+++ b/app/templates/components/questionnaire/fastq-file-pair-list.hbs
@@ -4,7 +4,7 @@
 </div>
 <div class="col-md-6 file-group-list-selections">
   <label>Selected {{ groupTitle }} {{ groupSizeName }}</label>
-  {{#each groups as |pair pairIndex|}}
+  {{#each fastqFilePairs as |pair pairIndex|}}
     {{questionnaire/fastq-file-pair-row pair pairIndex (action 'removeAt')}}
   {{else}}
     {{questionnaire/empty-selection}}

--- a/app/templates/components/questionnaire/fastq-file-pair-row.hbs
+++ b/app/templates/components/questionnaire/fastq-file-pair-row.hbs
@@ -1,0 +1,6 @@
+<p>{{ groupName }} {{ displayIndex }}</p>
+<ul>
+  {{#if group.file1}}{{questionnaire/file-group-file group.file1 0 (action 'click')}}{{/if}}
+  {{#if group.file2}}{{questionnaire/file-group-file group.file2 1 (action 'click')}}{{/if}}
+</ul>
+{{yield}}

--- a/app/templates/components/questionnaire/fastq-file-pair-row.hbs
+++ b/app/templates/components/questionnaire/fastq-file-pair-row.hbs
@@ -1,4 +1,5 @@
-<p>{{ pairName }} {{ displayIndex }}</p>
+<p>Name: {{pairName}}</p>
+{{error-panel errors=errors}}
 <ul>
   {{#if pair.file1}}{{questionnaire/file-group-file pair.file1 0 (action 'click')}}{{/if}}
   {{#if pair.file2}}{{questionnaire/file-group-file pair.file2 1 (action 'click')}}{{/if}}

--- a/app/templates/components/questionnaire/fastq-file-pair-row.hbs
+++ b/app/templates/components/questionnaire/fastq-file-pair-row.hbs
@@ -1,6 +1,6 @@
-<p>{{ groupName }} {{ displayIndex }}</p>
+<p>{{ pairName }} {{ displayIndex }}</p>
 <ul>
-  {{#if group.file1}}{{questionnaire/file-group-file group.file1 0 (action 'click')}}{{/if}}
-  {{#if group.file2}}{{questionnaire/file-group-file group.file2 1 (action 'click')}}{{/if}}
+  {{#if pair.file1}}{{questionnaire/file-group-file pair.file1 0 (action 'click')}}{{/if}}
+  {{#if pair.file2}}{{questionnaire/file-group-file pair.file2 1 (action 'click')}}{{/if}}
 </ul>
 {{yield}}

--- a/app/templates/jobs/new/build-answer-set.hbs
+++ b/app/templates/jobs/new/build-answer-set.hbs
@@ -1,5 +1,4 @@
-{{questionnaire/answer-form model}}
-
+{{questionnaire/answer-form model answerFormErrors}}
 {{#bs-button type="default" onClick=(action 'back') class="back-button"}}Back{{/bs-button}}
 {{#bs-button type="primary" onClick=(action 'saveAndCreateJob') class="pull-right next-button"}}Save{{/bs-button}}
 

--- a/app/utils/component-settings.js
+++ b/app/utils/component-settings.js
@@ -17,12 +17,12 @@ const ComponentSettings = [
   },
   {
     // Bespin CWL file pair
-    cwlType: { type: 'array', items: '#bespin-types.yml/NamedFASTQFilePairType'}, // Defined in CWL
+    cwlType: { type: 'array', items: 'NamedFASTQFilePairType'}, // Defined in CWL
     name: 'fastq-file-pair-list',  // Component to render
     formats: [
       {
         title: 'FASTQ Pair',
-        format: 'http://edamontology.org/format_1930',
+        format: null, // The specific files should be http://edamontology.org/format_1930, but this is a structure
         fileNameRegexStr: '.*(fq$)|(fq.gz$)|(fastq$)|(fastq.gz$)',
         groupName: 'Sample'
       }

--- a/app/utils/component-settings.js
+++ b/app/utils/component-settings.js
@@ -10,6 +10,7 @@ const ComponentSettings = [
     formats: [
       {
         title: 'File',
+        format: 'http://edamontology.org/format_1915', // Generic format
         groupName: 'File Group'
       }
     ]
@@ -20,7 +21,7 @@ const ComponentSettings = [
     name: 'fastq-file-pair-list',  // Component to render
     formats: [
       {
-        title: 'FASTQ',
+        title: 'FASTQ Pair',
         format: 'http://edamontology.org/format_1930',
         fileNameRegexStr: '.*(fq$)|(fq.gz$)|(fastq$)|(fastq.gz$)',
         groupName: 'Sample'

--- a/app/utils/component-settings.js
+++ b/app/utils/component-settings.js
@@ -4,8 +4,20 @@
  */
 const ComponentSettings = [
   {
+    // Generic file group
     cwlType: { type: 'array', items: { type: 'array', items: 'File' } }, // From CWL
     name: 'file-group-list',  // Component to render
+    formats: [
+      {
+        title: 'File',
+        groupName: 'File Group'
+      }
+    ]
+  },
+  {
+    // Bespin CWL file pair
+    cwlType: { type: 'array', items: '#bespin-types.yml/NamedFASTQFilePairType'}, // Defined in CWL
+    name: 'fastq-file-pair-list',  // Component to render
     formats: [
       {
         title: 'FASTQ',

--- a/app/utils/fastq-file-item-list.js
+++ b/app/utils/fastq-file-item-list.js
@@ -1,11 +1,29 @@
 import Ember from 'ember';
 import { FileItemList, commonPrefix} from 'bespin-ui/utils/file-item-list';
 
+const DEFAULT_SEPARATOR = '_';
+
+function extractSampleName(name, separator) {
+  // Default to '_' if no separator
+  if(Ember.isEmpty(separator)) {
+    separator = DEFAULT_SEPARATOR;
+  }
+
+  // Remove the last . if any
+  name = name.split('.')[0];
+
+  // Now split on the separator
+  const sampleName = name.split(separator)[0];
+  return sampleName;
+}
+
 function makeSamplePair(fileItemGroup, fileItemPropertyName) {
   const fileItem1 = fileItemGroup.objectAt(0) || Ember.Object.create();
   const fileItem2 = fileItemGroup.objectAt(1) || Ember.Object.create();
+  const prefix = commonPrefix(fileItem1.get('name'), fileItem2.get('name'));
+  const sampleName = extractSampleName(prefix);
   return Ember.Object.create({
-    name: commonPrefix(fileItem1.get('name'), fileItem2.get('name')),
+    name: sampleName,
     file1: fileItem1.get(fileItemPropertyName),
     file2: fileItem2.get(fileItemPropertyName)
   });
@@ -30,4 +48,4 @@ const FASTQFileItemList = FileItemList.extend({
   })
 });
 
-export default FASTQFileItemList;
+export { FASTQFileItemList, extractSampleName };

--- a/app/utils/fastq-file-item-list.js
+++ b/app/utils/fastq-file-item-list.js
@@ -3,6 +3,17 @@ import { FileItemList, commonPrefix} from 'bespin-ui/utils/file-item-list';
 
 const DEFAULT_SEPARATOR = '_';
 
+function splitMultipleSeparators(name, separators) {
+  separators = separators || [];
+  // If more than 1 separator, replace all instances of other separators with the first, then split on first
+  const firstSeparator = separators[0];
+  separators.slice(1).forEach((otherSeparator) => {
+    name = name.replace(otherSeparator, firstSeparator);
+  });
+  return name.split(firstSeparator);
+}
+
+
 function extractSampleName(name, separator) {
   // Default to '_' if no separator
   if(Ember.isEmpty(separator)) {
@@ -17,6 +28,7 @@ function extractSampleName(name, separator) {
 function makeSamplePair(fileItemGroup, fileItemPropertyName) {
   const fileItem1 = fileItemGroup.objectAt(0) || Ember.Object.create();
   const fileItem2 = fileItemGroup.objectAt(1) || Ember.Object.create();
+
   const prefix = commonPrefix(fileItem1.get('name'), fileItem2.get('name'));
   const sampleName = extractSampleName(prefix);
   return Ember.Object.create({
@@ -60,4 +72,4 @@ const FASTQFileItemList = FileItemList.extend({
   })
 });
 
-export { FASTQFileItemList, extractSampleName };
+export { FASTQFileItemList, extractSampleName, splitMultipleSeparators };

--- a/app/utils/fastq-file-item-list.js
+++ b/app/utils/fastq-file-item-list.js
@@ -1,0 +1,33 @@
+import Ember from 'ember';
+import { FileItemList, commonPrefix} from 'bespin-ui/utils/file-item-list';
+
+function makeSamplePair(fileItemGroup, fileItemPropertyName) {
+  const fileItem1 = fileItemGroup.objectAt(0) || Ember.Object.create();
+  const fileItem2 = fileItemGroup.objectAt(1) || Ember.Object.create();
+  return Ember.Object.create({
+    name: commonPrefix(fileItem1.get('name'), fileItem2.get('name')),
+    file1: fileItem1.get(fileItemPropertyName),
+    file2: fileItem2.get(fileItemPropertyName)
+  });
+}
+// The internal data structure
+const FASTQFileItemList = FileItemList.extend({
+  groupSize: 2,
+
+  //For Presentation
+  fastqFilePairs: Ember.computed('fileItemGroups.[]', function() {
+    const fileItemGroups = this.get('fileItemGroups');
+    return fileItemGroups.map(function (fileItemGroup) {
+      return makeSamplePair(fileItemGroup, 'ddsFile')
+    });
+  }),
+  // in the component, groups is computed from fileItems.fileItemGroups and just pulls out the ddsfile
+  cwlObjectValue: Ember.computed('fileItemGroups.[]', function() {
+    const fileItemGroups = this.get('fileItemGroups');
+    return fileItemGroups.map(function (fileItemGroup) {
+      return makeSamplePair(fileItemGroup, 'cwlObject');
+    });
+  })
+});
+
+export default FASTQFileItemList;

--- a/app/utils/fastq-file-item-list.js
+++ b/app/utils/fastq-file-item-list.js
@@ -33,6 +33,12 @@ const FASTQFileItemList = FileItemList.extend({
     return this.get('fastqFilePairs.length') == fullGroups.get('length');
   }),
 
+  hasUniqueSampleNames: Ember.computed('fastqFilePairs.[]', function() {
+    const pairs = this.get('fastqFilePairs');
+    const uniquePairs = this.get('fastqFilePairs').uniqBy('name');
+    return pairs.get('length') === uniquePairs.get('length');
+  }),
+
   //For Presentation
   fastqFilePairs: Ember.computed('fileItemGroups.[]', function() {
     const fileItemGroups = this.get('fileItemGroups');

--- a/app/utils/fastq-file-item-list.js
+++ b/app/utils/fastq-file-item-list.js
@@ -39,6 +39,11 @@ const FASTQFileItemList = FileItemList.extend({
     return pairs.get('length') === uniquePairs.get('length');
   }),
 
+  hasUnnamedSamples: Ember.computed('fastqFilePairs.[]', function() {
+    const emptyPairNames = this.get('fastqFilePairs').filterBy('name', '');
+    return emptyPairNames.get('length') > 0;
+  }),
+
   //For Presentation
   fastqFilePairs: Ember.computed('fileItemGroups.[]', function() {
     const fileItemGroups = this.get('fileItemGroups');

--- a/app/utils/fastq-file-item-list.js
+++ b/app/utils/fastq-file-item-list.js
@@ -1,9 +1,8 @@
 import Ember from 'ember';
-import { FileItemList, commonPrefix} from 'bespin-ui/utils/file-item-list';
-
-const DEFAULT_SEPARATOR = '_';
+import { FileItemList } from 'bespin-ui/utils/file-item-list';
 
 function splitMultipleSeparators(name, separators) {
+  name = name || '';
   separators = separators || [];
   // If more than 1 separator, replace all instances of other separators with the first, then split on first
   const firstSeparator = separators[0];
@@ -13,24 +12,24 @@ function splitMultipleSeparators(name, separators) {
   return name.split(firstSeparator);
 }
 
+const DEFAULT_SEPARATORS = ['_','-',' '];
 
-function extractSampleName(name, separator) {
-  // Default to '_' if no separator
-  if(Ember.isEmpty(separator)) {
-    separator = DEFAULT_SEPARATOR;
+function extractSampleName(name, separators) {
+  if(Ember.isEmpty(separators)) {
+    separators = DEFAULT_SEPARATORS;
   }
-
-  // Split on the separator
-  const sampleName = name.split(separator)[0];
-  return sampleName;
+  return splitMultipleSeparators(name, separators)[0];
 }
 
 function makeSamplePair(fileItemGroup, fileItemPropertyName) {
   const fileItem1 = fileItemGroup.objectAt(0) || Ember.Object.create();
   const fileItem2 = fileItemGroup.objectAt(1) || Ember.Object.create();
-
-  const prefix = commonPrefix(fileItem1.get('name'), fileItem2.get('name'));
-  const sampleName = extractSampleName(prefix);
+  const sampleName1 = extractSampleName(fileItem1.get('name'));
+  const sampleName2 = extractSampleName(fileItem2.get('name'));
+  let sampleName = '';
+  if(sampleName1 === sampleName2) {
+    sampleName = sampleName1;
+  }
   return Ember.Object.create({
     name: sampleName,
     file1: fileItem1.get(fileItemPropertyName),

--- a/app/utils/fastq-file-item-list.js
+++ b/app/utils/fastq-file-item-list.js
@@ -29,7 +29,7 @@ function makeSamplePair(fileItemGroup, fileItemPropertyName) {
 const FASTQFileItemList = FileItemList.extend({
   groupSize: 2,
   isComplete: Ember.computed('fileItemGroups.[]', function() {
-    const fullGroups = this.get('fastqFilePairs').filterBy('length', this.get('groupSize'));
+    const fullGroups = this.get('fileItemGroups').filterBy('length', this.get('groupSize'));
     return this.get('fastqFilePairs.length') == fullGroups.get('length');
   }),
 

--- a/app/utils/fastq-file-item-list.js
+++ b/app/utils/fastq-file-item-list.js
@@ -28,6 +28,10 @@ function makeSamplePair(fileItemGroup, fileItemPropertyName) {
 // The internal data structure
 const FASTQFileItemList = FileItemList.extend({
   groupSize: 2,
+  isComplete: Ember.computed('fileItemGroups.[]', function() {
+    const fullGroups = this.get('fastqFilePairs').filterBy('length', this.get('groupSize'));
+    return this.get('fastqFilePairs.length') == fullGroups.get('length');
+  }),
 
   //For Presentation
   fastqFilePairs: Ember.computed('fileItemGroups.[]', function() {

--- a/app/utils/fastq-file-item-list.js
+++ b/app/utils/fastq-file-item-list.js
@@ -9,10 +9,7 @@ function extractSampleName(name, separator) {
     separator = DEFAULT_SEPARATOR;
   }
 
-  // Remove the last . if any
-  name = name.split('.')[0];
-
-  // Now split on the separator
+  // Split on the separator
   const sampleName = name.split(separator)[0];
   return sampleName;
 }

--- a/app/utils/file-item-list.js
+++ b/app/utils/file-item-list.js
@@ -117,7 +117,7 @@ const commonPrefix = function(filename1, filename2) {
   // Given two filenames, return a common prefix
   filename1 = filename1 || '';
   filename2 = filename2 || '';
-  let commonLength = Math.min(filename1.length, filename2.length) - 1;
+  let commonLength = Math.min(filename1.length, filename2.length);
   while(filename1.substring(0, commonLength) != filename2.substring(0, commonLength)) {
     commonLength--;
   }

--- a/app/utils/file-item-list.js
+++ b/app/utils/file-item-list.js
@@ -121,7 +121,12 @@ const commonPrefix = function(filename1, filename2) {
   while(filename1.substring(0, commonLength) != filename2.substring(0, commonLength)) {
     commonLength--;
   }
-  return filename1.substring(0, commonLength);
+
+  if(commonLength > 0) {
+    return filename1.substring(0, commonLength);
+  } else {
+    return `${filename1}+${filename2}`;
+  }
 };
 
 export {

--- a/app/utils/file-item-list.js
+++ b/app/utils/file-item-list.js
@@ -113,7 +113,7 @@ const FileItemList = Ember.Object.extend({
   ddsFiles: Ember.computed.mapBy('content', 'ddsFile')
 });
 
-const commonPrefix = function(filename1, filename2) {
+function commonPrefix(filename1, filename2) {
   // Given two filenames, return a common prefix
   filename1 = filename1 || '';
   filename2 = filename2 || '';
@@ -127,7 +127,7 @@ const commonPrefix = function(filename1, filename2) {
   } else {
     return `${filename1}+${filename2}`;
   }
-};
+}
 
 export {
   FileItemList,

--- a/app/utils/file-item-list.js
+++ b/app/utils/file-item-list.js
@@ -121,12 +121,7 @@ function commonPrefix(filename1, filename2) {
   while(filename1.substring(0, commonLength) != filename2.substring(0, commonLength)) {
     commonLength--;
   }
-
-  if(commonLength > 0) {
-    return filename1.substring(0, commonLength);
-  } else {
-    return `${filename1}+${filename2}`;
-  }
+  return filename1.substring(0, commonLength);
 }
 
 export {

--- a/app/utils/file-item-list.js
+++ b/app/utils/file-item-list.js
@@ -16,7 +16,8 @@ const FileItem = Ember.Object.extend({
 
   destroy() {
     this.get('inputFile').destroyRecord();
-  }
+  },
+  name: Ember.computed.oneWay('ddsFile.name')
 });
 
 const FileItemList = Ember.Object.extend({
@@ -112,7 +113,19 @@ const FileItemList = Ember.Object.extend({
   ddsFiles: Ember.computed.mapBy('content', 'ddsFile')
 });
 
+const commonPrefix = function(filename1, filename2) {
+  // Given two filenames, return a common prefix
+  filename1 = filename1 || '';
+  filename2 = filename2 || '';
+  let commonLength = Math.min(filename1.length, filename2.length) - 1;
+  while(filename1.substring(0, commonLength) != filename2.substring(0, commonLength)) {
+    commonLength--;
+  }
+  return filename1.substring(0, commonLength);
+};
+
 export {
   FileItemList,
-  FileItem
+  FileItem,
+  commonPrefix
 };

--- a/tests/integration/components/questionnaire/fastq-file-pair-list-test.js
+++ b/tests/integration/components/questionnaire/fastq-file-pair-list-test.js
@@ -1,25 +1,21 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import StoreStub from '../../../helpers/store-stub';
 
 moduleForComponent('questionnaire/fastq-file-pair-list', 'Integration | Component | questionnaire/fastq file pair list', {
-  integration: true
+  integration: true,
+  beforeEach: function() {
+    this.register('service:store', StoreStub);
+    this.inject.service('store', {as: 'store'});
+    this.get('store').reset();
+    this.set('store.queryFunction', function() {
+      return [{name: 'file1.txt', kind: 'dds-file'}, {name: 'file2.txt', kind: 'dds-file'}];
+    });
+  }
 });
 
 test('it renders', function(assert) {
-
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
-
   this.render(hbs`{{questionnaire/fastq-file-pair-list}}`);
-
-  assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#questionnaire/fastq-file-pair-list}}
-      template block text
-    {{/questionnaire/fastq-file-pair-list}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
+  // TODO: Write tests
+  assert.ok(true);
 });

--- a/tests/integration/components/questionnaire/fastq-file-pair-list-test.js
+++ b/tests/integration/components/questionnaire/fastq-file-pair-list-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('questionnaire/fastq-file-pair-list', 'Integration | Component | questionnaire/fastq file pair list', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{questionnaire/fastq-file-pair-list}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#questionnaire/fastq-file-pair-list}}
+      template block text
+    {{/questionnaire/fastq-file-pair-list}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/questionnaire/fastq-file-pair-list-test.js
+++ b/tests/integration/components/questionnaire/fastq-file-pair-list-test.js
@@ -7,11 +7,6 @@ moduleForComponent('questionnaire/fastq-file-pair-list', 'Integration | Componen
   integration: true,
   beforeEach: function() {
     this.register('service:store', StoreStub);
-    this.inject.service('store', {as: 'store'});
-    this.get('store').reset();
-    this.set('store.queryFunction', function() {
-      return [{name: 'file1.txt', kind: 'dds-file'}, {name: 'file2.txt', kind: 'dds-file'}];
-    });
   }
 });
 

--- a/tests/integration/components/questionnaire/fastq-file-pair-list-test.js
+++ b/tests/integration/components/questionnaire/fastq-file-pair-list-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import StoreStub from '../../../helpers/store-stub';
+import Ember from 'ember';
 
 moduleForComponent('questionnaire/fastq-file-pair-list', 'Integration | Component | questionnaire/fastq file pair list', {
   integration: true,
@@ -14,8 +15,27 @@ moduleForComponent('questionnaire/fastq-file-pair-list', 'Integration | Componen
   }
 });
 
-test('it renders', function(assert) {
-  this.render(hbs`{{questionnaire/fastq-file-pair-list}}`);
-  // TODO: Write tests
-  assert.ok(true);
+test('it shows/hides errors based on answerFormErrors.show', function(assert) {
+  this.set('fieldName', 'field-name');
+  this.set('answerFormErrors', Ember.Object.create({
+    show: true,
+    errors: [{field: 'field-name', message: 'Error Message'}],
+    setError() { }
+  }));
+  this.render(hbs`{{questionnaire/fastq-file-pair-list fieldName=fieldName answerFormErrors=answerFormErrors }}`);
+  assert.equal(this.$('.error-panel').text().trim(), 'Error Message');
+
+  this.set('answerFormErrors.show', false);
+  this.render(hbs`{{questionnaire/fastq-file-pair-list fieldName=fieldName answerFormErrors=answerFormErrors }}`);
+  assert.equal(this.$('.error-panel').text().trim(), '');
+});
+
+test('it renders a fastq-file-pair-row for each selected pair', function(assert) {
+  const fileItems = Ember.Object.create({
+      fastqFilePairs: [{},{}]
+    }
+  );
+  this.set('fileItems', fileItems);
+  this.render(hbs`{{questionnaire/fastq-file-pair-list fileItems=fileItems}}`);
+  assert.equal(this.$('.fastq-file-pair-row').length, 2)
 });

--- a/tests/integration/components/questionnaire/fastq-file-pair-list-test.js
+++ b/tests/integration/components/questionnaire/fastq-file-pair-list-test.js
@@ -34,3 +34,22 @@ test('it renders a fastq-file-pair-row for each selected pair', function(assert)
   this.render(hbs`{{questionnaire/fastq-file-pair-list fileItems=fileItems}}`);
   assert.equal(this.$('.fastq-file-pair-row').length, 2)
 });
+
+test('it correctly observes error array', function(assert) {
+  const errors = Ember.Object.create({
+    show: true,
+    errors: [{field: 'field-name', message: 'Empty'}],
+    setError() { }
+  });
+  this.set('answerFormErrors', errors);
+  this.set('fieldName', 'field-name');
+  Ember.run(() => {
+    // Initially empty
+    this.render(hbs`{{questionnaire/fastq-file-pair-list fieldName=fieldName answerFormErrors=answerFormErrors}}`);
+    assert.equal(this.$('.error-panel').text().trim(), 'Empty');
+
+    // Now replace the errors and verify the new error is displayed
+    this.set('answerFormErrors.errors', [{field: 'field-name', message: 'Incomplete'}]);
+    assert.equal(this.$('.error-panel').text().trim(), 'Incomplete');
+  });
+});

--- a/tests/integration/components/questionnaire/fastq-file-pair-row-test.js
+++ b/tests/integration/components/questionnaire/fastq-file-pair-row-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('questionnaire/fastq-file-pair-row', 'Integration | Component | questionnaire/fastq file pair row', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{questionnaire/fastq-file-pair-row}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#questionnaire/fastq-file-pair-row}}
+      template block text
+    {{/questionnaire/fastq-file-pair-row}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/questionnaire/fastq-file-pair-row-test.js
+++ b/tests/integration/components/questionnaire/fastq-file-pair-row-test.js
@@ -6,20 +6,7 @@ moduleForComponent('questionnaire/fastq-file-pair-row', 'Integration | Component
 });
 
 test('it renders', function(assert) {
-
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
-
   this.render(hbs`{{questionnaire/fastq-file-pair-row}}`);
-
-  assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#questionnaire/fastq-file-pair-row}}
-      template block text
-    {{/questionnaire/fastq-file-pair-row}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.ok(true);
+  //TODO: Write test
 });

--- a/tests/integration/components/questionnaire/fastq-file-pair-row-test.js
+++ b/tests/integration/components/questionnaire/fastq-file-pair-row-test.js
@@ -1,12 +1,42 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
 
 moduleForComponent('questionnaire/fastq-file-pair-row', 'Integration | Component | questionnaire/fastq file pair row', {
   integration: true
 });
 
-test('it renders', function(assert) {
-  this.render(hbs`{{questionnaire/fastq-file-pair-row}}`);
-  assert.ok(true);
-  //TODO: Write test
+test('it renders both files from the pair', function(assert) {
+  const pair = Ember.Object.create({
+    name: 'pairName',
+    file1: { name: 'pairFile1' },
+    file2: { name: 'pairFile2' }
+  });
+  this.set('pair', pair);
+  this.render(hbs`{{questionnaire/fastq-file-pair-row pair}}`);
+  assert.equal(this.$('.file-group-file').length, 2);
+  assert.equal(this.$('.file-group-file').eq(0).text().trim(), 'pairFile1');
+  assert.equal(this.$('.file-group-file').eq(1).text().trim(), 'pairFile2');
+});
+
+test('it does not render empty files from the pair', function(assert) {
+  const pair = Ember.Object.create({
+    name: 'pairName',
+    file1: { name: 'pairFile1' },
+    file2: null,
+  });
+  Ember.run(() => {
+    this.set('pair', pair);
+    this.render(hbs`{{questionnaire/fastq-file-pair-row pair}}`);
+    assert.equal(this.$('.file-group-file').length, 1);
+    assert.equal(this.$('.file-group-file').eq(0).text().trim(), 'pairFile1');
+
+    pair.set('file1', null);
+    pair.set('file2', {name: 'pairFile2'});
+    this.render(hbs`{{questionnaire/fastq-file-pair-row pair}}`);
+    assert.equal(this.$('.file-group-file').length, 1);
+
+    // Do not render the first file when not set
+    assert.equal(this.$('.file-group-file').eq(0).text().trim(), 'pairFile2');
+  });
 });

--- a/tests/unit/components/questionnaire/answer-form-list-test.js
+++ b/tests/unit/components/questionnaire/answer-form-list-test.js
@@ -37,7 +37,7 @@ test('it computes fields property', function (assert) {
 test('it computes fields componentSettings', function (assert) {
   let userFields = [
     {type: { type: 'array', items: { type: 'array', items: 'File' } }, name: 'fieldName1',
-      format: 'http://edamontology.org/format_1930' },
+      format: 'http://edamontology.org/format_1915' },
     {type: 'fieldType2', name: 'fieldName2' }
   ];
   let questionnaire = Ember.Object.create({ userFieldsJson: userFields});
@@ -48,13 +48,12 @@ test('it computes fields componentSettings', function (assert) {
     name: 'fieldName1',
     componentName: 'questionnaire/file-group-list',
     formatSettings: {
-      title: 'FASTQ',
-      format: 'http://edamontology.org/format_1930',
-      fileNameRegexStr: '.*(fq$)|(fq.gz$)|(fastq$)|(fastq.gz$)',
-      groupName: 'Sample'
+      title: 'File',
+      format: 'http://edamontology.org/format_1915',
+      groupName: 'File Group'
     },
   });
-  assert.deepEqual(fields, [expectedField]);
+  assert.equal(JSON.stringify(fields), JSON.stringify([expectedField]));
 });
 
 test('it calculates componentNameForType', function (assert) {
@@ -75,8 +74,8 @@ test('it calculates formatSettingsForComponentAndFormat', function (assert) {
   let component = this.subject();
   let componentSettings = component.componentSettingsForCwlType(fileArrayArrayType);
   let formatSettings = component.formatSettingsForComponentAndFormat(componentSettings,
-    'http://edamontology.org/format_1930');
-  assert.equal(formatSettings.title, 'FASTQ');
+    'http://edamontology.org/format_1915');
+  assert.equal(formatSettings.title, 'File');
 });
 
 test('it handles answerChanged action', function (assert) {

--- a/tests/unit/components/questionnaire/fastq-file-pair-list-test.js
+++ b/tests/unit/components/questionnaire/fastq-file-pair-list-test.js
@@ -15,7 +15,7 @@ test('it records error when no pairs chosen', function(assert) {
       assert.equal(fieldName, 'sample-pairs1');
       assert.equal(errorText, 'Please choose at least 1 sample pair');
     },
-    clearError(fieldName) {
+    clearError(/* fieldName */) {
       assert.notOk(true); // clearError should not be called
     }
   });
@@ -35,7 +35,7 @@ test('it records error when pairs incomplete', function(assert) {
       assert.equal(fieldName, 'sample-pairs2');
       assert.equal(errorText, 'Please ensure all samples are paired');
     },
-    clearError(fieldName) {
+    clearError(/* fieldName */) {
       assert.notOk(true); // clearError should not be called
     }
   });
@@ -51,7 +51,7 @@ test('it records no error when pairs complete', function(assert) {
   assert.expect(1);
   const complete = Ember.Object.create({ fastqFilePairs: [1,2,3,4], isComplete: true });
   const mockErrors = Ember.Object.create({
-    setError(fieldName, errorText) {
+    setError(/* fieldName, errorText */) {
       assert.notOk(true); // Should not call this!
     },
     clearError(fieldName) {

--- a/tests/unit/components/questionnaire/fastq-file-pair-list-test.js
+++ b/tests/unit/components/questionnaire/fastq-file-pair-list-test.js
@@ -1,0 +1,68 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
+
+moduleForComponent('questionnaire/fastq-file-pair-list', 'Unit | Component | questionnaire/fastq file pair list', {
+  needs: ['service:dds-projects', 'service:dds-user-credentials'],
+  unit: true
+});
+
+
+test('it records error when no pairs chosen', function(assert) {
+  assert.expect(2);
+  const empty = Ember.Object.create({ fastqFilePairs: [], isComplete: true });
+  const mockErrors = Ember.Object.create({
+    setError(fieldName, errorText) {
+      assert.equal(fieldName, 'sample-pairs1');
+      assert.equal(errorText, 'Please choose at least 1 sample pair');
+    },
+    clearError(fieldName) {
+      assert.notOk(true); // clearError should not be called
+    }
+  });
+
+  this.subject({
+    fieldName: 'sample-pairs1',
+    fileItems: empty,
+    answerFormErrors: mockErrors
+  });
+});
+
+test('it records error when pairs incomplete', function(assert) {
+  assert.expect(2);
+  const incomplete = Ember.Object.create({ fastqFilePairs: [1], isComplete: false });
+  const mockErrors = Ember.Object.create({
+    setError(fieldName, errorText) {
+      assert.equal(fieldName, 'sample-pairs2');
+      assert.equal(errorText, 'Please ensure all samples are paired');
+    },
+    clearError(fieldName) {
+      assert.notOk(true); // clearError should not be called
+    }
+  });
+
+  this.subject({
+    fieldName: 'sample-pairs2',
+    fileItems: incomplete,
+    answerFormErrors: mockErrors
+  });
+});
+
+test('it records no error when pairs complete', function(assert) {
+  assert.expect(1);
+  const complete = Ember.Object.create({ fastqFilePairs: [1,2,3,4], isComplete: true });
+  const mockErrors = Ember.Object.create({
+    setError(fieldName, errorText) {
+      assert.notOk(true); // Should not call this!
+    },
+    clearError(fieldName) {
+      assert.equal(fieldName, 'sample-pairs3');
+    }
+  });
+
+  this.subject({
+    fieldName: 'sample-pairs3',
+    fileItems: complete,
+    answerFormErrors: mockErrors
+  });
+});
+

--- a/tests/unit/components/questionnaire/fastq-file-pair-list-test.js
+++ b/tests/unit/components/questionnaire/fastq-file-pair-list-test.js
@@ -9,7 +9,7 @@ moduleForComponent('questionnaire/fastq-file-pair-list', 'Unit | Component | que
 
 test('it records error when no pairs chosen', function(assert) {
   assert.expect(2);
-  const empty = Ember.Object.create({ fastqFilePairs: [], isComplete: true });
+  const empty = Ember.Object.create({ fastqFilePairs: [], isComplete: true, hasUniqueSampleNames: true });
   const mockErrors = Ember.Object.create({
     setError(fieldName, errorText) {
       assert.equal(fieldName, 'sample-pairs1');
@@ -29,7 +29,7 @@ test('it records error when no pairs chosen', function(assert) {
 
 test('it records error when pairs incomplete', function(assert) {
   assert.expect(2);
-  const incomplete = Ember.Object.create({ fastqFilePairs: [1], isComplete: false });
+  const incomplete = Ember.Object.create({ fastqFilePairs: [1], isComplete: false, hasUniqueSampleNames: true });
   const mockErrors = Ember.Object.create({
     setError(fieldName, errorText) {
       assert.equal(fieldName, 'sample-pairs2');
@@ -49,7 +49,7 @@ test('it records error when pairs incomplete', function(assert) {
 
 test('it records no error when pairs complete', function(assert) {
   assert.expect(1);
-  const complete = Ember.Object.create({ fastqFilePairs: [1,2,3,4], isComplete: true });
+  const complete = Ember.Object.create({ fastqFilePairs: [1,2,3,4], isComplete: true, hasUniqueSampleNames: true });
   const mockErrors = Ember.Object.create({
     setError(/* fieldName, errorText */) {
       assert.notOk(true); // Should not call this!
@@ -62,6 +62,27 @@ test('it records no error when pairs complete', function(assert) {
   this.subject({
     fieldName: 'sample-pairs3',
     fileItems: complete,
+    answerFormErrors: mockErrors
+  });
+});
+
+
+test('it records error when pairs do not have unique sample names', function(assert) {
+  assert.expect(2);
+  const duplicates = Ember.Object.create({ fastqFilePairs: [1,1], isComplete: true, hasUniqueSampleNames: false });
+  const mockErrors = Ember.Object.create({
+    setError(fieldName, errorText) {
+      assert.equal(fieldName, 'sample-pairs4');
+      assert.equal(errorText, 'Please ensure all pairs chosen have unique names');
+    },
+    clearError(/* fieldName */) {
+      assert.notOk(true); // clearError should not be called
+    }
+  });
+
+  this.subject({
+    fieldName: 'sample-pairs4',
+    fileItems: duplicates,
     answerFormErrors: mockErrors
   });
 });

--- a/tests/unit/components/questionnaire/fastq-file-pair-list-test.js
+++ b/tests/unit/components/questionnaire/fastq-file-pair-list-test.js
@@ -6,14 +6,22 @@ moduleForComponent('questionnaire/fastq-file-pair-list', 'Unit | Component | que
   unit: true
 });
 
+const MockFileItemList = Ember.Object.extend({
+  // Default to everything's fine
+  fastqFilePairs: null,
+  isComplete: true,
+  hasUniqueSampleNames: true,
+  hasUnnamedSamples: false
+});
+
 
 test('it records error when no pairs chosen', function(assert) {
   assert.expect(2);
-  const empty = Ember.Object.create({ fastqFilePairs: [], isComplete: true, hasUniqueSampleNames: true });
+  const empty = MockFileItemList.create({fastqFilePairs: []});
   const mockErrors = Ember.Object.create({
     setError(fieldName, errorText) {
       assert.equal(fieldName, 'sample-pairs1');
-      assert.equal(errorText, 'Please choose at least 1 sample pair');
+      assert.equal(errorText, 'Please choose at least 1 sample pair.');
     },
     clearError(/* fieldName */) {
       assert.notOk(true); // clearError should not be called
@@ -29,11 +37,11 @@ test('it records error when no pairs chosen', function(assert) {
 
 test('it records error when pairs incomplete', function(assert) {
   assert.expect(2);
-  const incomplete = Ember.Object.create({ fastqFilePairs: [1], isComplete: false, hasUniqueSampleNames: true });
+  const incomplete = MockFileItemList.create({fastqFilePairs: [1], isComplete: false});
   const mockErrors = Ember.Object.create({
     setError(fieldName, errorText) {
       assert.equal(fieldName, 'sample-pairs2');
-      assert.equal(errorText, 'Please ensure all samples are paired');
+      assert.equal(errorText, 'Please ensure all samples are paired.');
     },
     clearError(/* fieldName */) {
       assert.notOk(true); // clearError should not be called
@@ -47,9 +55,9 @@ test('it records error when pairs incomplete', function(assert) {
   });
 });
 
-test('it records no error when pairs complete', function(assert) {
+test('it records no error when everything good', function(assert) {
   assert.expect(1);
-  const complete = Ember.Object.create({ fastqFilePairs: [1,2,3,4], isComplete: true, hasUniqueSampleNames: true });
+  const complete = MockFileItemList.create();
   const mockErrors = Ember.Object.create({
     setError(/* fieldName, errorText */) {
       assert.notOk(true); // Should not call this!
@@ -66,14 +74,13 @@ test('it records no error when pairs complete', function(assert) {
   });
 });
 
-
 test('it records error when pairs do not have unique sample names', function(assert) {
   assert.expect(2);
-  const duplicates = Ember.Object.create({ fastqFilePairs: [1,1], isComplete: true, hasUniqueSampleNames: false });
+  const duplicates = MockFileItemList.create({fastqFilePairs: [1], hasUniqueSampleNames: false});
   const mockErrors = Ember.Object.create({
     setError(fieldName, errorText) {
       assert.equal(fieldName, 'sample-pairs4');
-      assert.equal(errorText, 'Please ensure all pairs chosen have unique names');
+      assert.equal(errorText, 'Please ensure all pairs chosen have unique names.');
     },
     clearError(/* fieldName */) {
       assert.notOk(true); // clearError should not be called
@@ -83,6 +90,26 @@ test('it records error when pairs do not have unique sample names', function(ass
   this.subject({
     fieldName: 'sample-pairs4',
     fileItems: duplicates,
+    answerFormErrors: mockErrors
+  });
+});
+
+test('it records error when pairs have unnamed samples', function(assert) {
+  assert.expect(2);
+  const unnamed = MockFileItemList.create({hasUnnamedSamples: true});
+  const mockErrors = Ember.Object.create({
+    setError(fieldName, errorText) {
+      assert.equal(fieldName, 'sample-pairs5');
+      assert.equal(errorText.indexOf('Unable to determine sample names'), 0);
+    },
+    clearError(/* fieldName */) {
+      assert.notOk(true); // clearError should not be called
+    }
+  });
+
+  this.subject({
+    fieldName: 'sample-pairs5',
+    fileItems: unnamed,
     answerFormErrors: mockErrors
   });
 });

--- a/tests/unit/components/questionnaire/fastq-file-pair-row-test.js
+++ b/tests/unit/components/questionnaire/fastq-file-pair-row-test.js
@@ -1,0 +1,20 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
+
+moduleForComponent('questionnaire/fastq-file-pair-row', 'Unit | Component | questionnaire/fastq file pair row', {
+  unit: true
+});
+
+test('it renders error message for empty file in pair', function(assert) {
+  const pair = Ember.Object.create({ file1: 'file1', file2: null, name: null });
+  const component = this.subject({pair: pair});
+  const errors = component.get('errors');
+  assert.equal(errors[0].get('message'), 'Select two files to detect sample name.');
+});
+
+test('it renders error message for empty name in pair', function(assert) {
+  const pair = Ember.Object.create({ file1: 'file1', file2: 'file2', name: null });
+  const component = this.subject({pair: pair});
+  const errors = component.get('errors');
+  assert.equal(errors[0].get('message'), 'No sample name detected. File names must begin with a common name to detect sample name.');
+});

--- a/tests/unit/utils/fastq-file-item-list-test.js
+++ b/tests/unit/utils/fastq-file-item-list-test.js
@@ -55,7 +55,7 @@ test('it extracts sample names', function(assert) {
 test('It recalculates sample name as files are added', function(assert) {
   let fileItemList = FASTQFileItemList.create();
   fileItemList.addFileItem(makeMockFileItem('AB1234_L001_R1.fastq'));
-  assert.equal(fileItemList.get('fastqFilePairs')[0].get('name'), 'AB1234');
+  assert.equal(fileItemList.get('fastqFilePairs')[0].get('name'), ''); // initially no common prefix since only one file
   fileItemList.addFileItem(makeMockFileItem('AB4567_L001_R1.fastq'));
   assert.equal(fileItemList.get('fastqFilePairs')[0].get('name'), 'AB');
 });

--- a/tests/unit/utils/fastq-file-item-list-test.js
+++ b/tests/unit/utils/fastq-file-item-list-test.js
@@ -1,0 +1,46 @@
+import FASTQFileItemList from 'bespin-ui/utils/fastq-file-item-list';
+import { module, test } from 'qunit';
+import Ember from 'ember';
+
+module('Unit | Utility | fastq file item list');
+
+function makeMockFileItem(name) {
+  return Ember.Object.create({
+    name: name,
+    ddsFile: Ember.Object.create(
+      {name: name, kind: 'dds-file'}
+      ),
+    cwlObject: {
+      class: 'File',
+      path: name
+    }
+  });
+}
+
+test('it calculates fastqFilePairs', function(assert) {
+  let fileItemList = FASTQFileItemList.create();
+  fileItemList.addFileItem(makeMockFileItem('abc1'));
+  fileItemList.addFileItem(makeMockFileItem('abc2'));
+  fileItemList.addFileItem(makeMockFileItem('def1'));
+  fileItemList.addFileItem(makeMockFileItem('def2'));
+  const expectedPairs = [
+    {name: 'abc', file1: {name: 'abc1', kind: 'dds-file'}, file2: {name: 'abc2', kind: 'dds-file'}},
+    {name: 'def', file1: {name: 'def1', kind: 'dds-file'}, file2: {name: 'def2', kind: 'dds-file'}}
+    ];
+  const calculatedPairs = fileItemList.get('fastqFilePairs');
+  assert.equal(JSON.stringify(calculatedPairs), JSON.stringify(expectedPairs))
+});
+
+test('it calculates cwlObjectValue', function(assert) {
+  let fileItemList = FASTQFileItemList.create();
+  fileItemList.addFileItem(makeMockFileItem('abc1'));
+  fileItemList.addFileItem(makeMockFileItem('abc2'));
+  fileItemList.addFileItem(makeMockFileItem('def1'));
+  fileItemList.addFileItem(makeMockFileItem('def2'));
+  const expectedCWLObjectValue = [
+    {name: 'abc', file1: {class: 'File', path: 'abc1'}, file2: {class: 'File', path: 'abc2'}},
+    {name: 'def', file1: {class: 'File', path: 'def1'}, file2: {class: 'File', path: 'def2'}},
+  ];
+  const calculatedCWLObjectValue = fileItemList.get('cwlObjectValue');
+  assert.equal(JSON.stringify(calculatedCWLObjectValue), JSON.stringify(expectedCWLObjectValue))
+});

--- a/tests/unit/utils/fastq-file-item-list-test.js
+++ b/tests/unit/utils/fastq-file-item-list-test.js
@@ -62,8 +62,8 @@ test('It recalculates sample name as files are added', function(assert) {
 
 test('It sets empty sample name when no match before delimiter', function(assert) {
   let fileItemList = FASTQFileItemList.create();
-  fileItemList.addFileItem(makeMockFileItem('AB1234_L001_R1.fastq'));
-  fileItemList.addFileItem(makeMockFileItem('AB1235_L001_R2.fastq'));
+  fileItemList.addFileItem(makeMockFileItem('SA04059_S3_L007_R2_001.fastq.gz'));
+  fileItemList.addFileItem(makeMockFileItem('SA03505_S1_L007_R2_001.fastq.gz'));
   assert.equal(fileItemList.get('fastqFilePairs')[0].get('name'), '');
 });
 

--- a/tests/unit/utils/fastq-file-item-list-test.js
+++ b/tests/unit/utils/fastq-file-item-list-test.js
@@ -1,4 +1,4 @@
-import FASTQFileItemList from 'bespin-ui/utils/fastq-file-item-list';
+import { FASTQFileItemList, extractSampleName } from 'bespin-ui/utils/fastq-file-item-list';
 import { module, test } from 'qunit';
 import Ember from 'ember';
 
@@ -43,4 +43,11 @@ test('it calculates cwlObjectValue', function(assert) {
   ];
   const calculatedCWLObjectValue = fileItemList.get('cwlObjectValue');
   assert.equal(JSON.stringify(calculatedCWLObjectValue), JSON.stringify(expectedCWLObjectValue))
+});
+
+test('it extracts sample names', function(assert) {
+  assert.equal(extractSampleName('SA1234_XYZ_R2.fastq.gz'),'SA1234'); // Typical _ delimiter and . extension
+  assert.equal(extractSampleName('ABC.D_E_F.fastq'),'ABC'); // Ignores _ delimiter after . extension
+  assert.equal(extractSampleName('ABC-DEF', '-'), 'ABC'); // Uses custom delimiter
+  assert.equal(extractSampleName('ABC-DEF'), 'ABC-DEF'); // Returns original string when no _ or .
 });

--- a/tests/unit/utils/fastq-file-item-list-test.js
+++ b/tests/unit/utils/fastq-file-item-list-test.js
@@ -59,3 +59,33 @@ test('It recalculates sample name as files are added', function(assert) {
   fileItemList.addFileItem(makeMockFileItem('AB4567_L001_R1.fastq'));
   assert.equal(fileItemList.get('fastqFilePairs')[0].get('name'), 'AB');
 });
+
+test('it calculates isComplete', function(assert) {
+  let fileItemList = FASTQFileItemList.create();
+  Ember.run(() => {
+    // First, check an empty list
+    assert.equal(fileItemList.get('fastqFilePairs.length'), 0);
+    assert.ok(fileItemList.get('isComplete')); // Empty list should be complete
+
+    // Now, add a single item. list should not be complete since group size is 2
+    fileItemList.addFileItem(makeMockFileItem('abc1'));
+    assert.equal(fileItemList.get('groupSize'), 2); // 2 = pair
+    assert.equal(fileItemList.get('fastqFilePairs.length'), 1); // 1 pair
+    assert.notOk(fileItemList.get('isComplete')); // not complete
+
+    // Add a second item, list should be complete
+    fileItemList.addFileItem(makeMockFileItem('def2'));
+    assert.equal(fileItemList.get('fastqFilePairs.length'), 1); // still 1 pair
+    assert.ok(fileItemList.get('isComplete')); // complete
+
+    // Remove the item, list should again be incomplete
+    fileItemList.removeFileItem(0, 0);
+    assert.notOk(fileItemList.get('isComplete')); // not complete
+
+    // Add 3 more, list should be complete again
+    fileItemList.addFileItem(makeMockFileItem('ghi3'));
+    fileItemList.addFileItem(makeMockFileItem('jkl4'));
+    fileItemList.addFileItem(makeMockFileItem('mno5'));
+    assert.ok(fileItemList.get('isComplete')); // complete
+  });
+});

--- a/tests/unit/utils/fastq-file-item-list-test.js
+++ b/tests/unit/utils/fastq-file-item-list-test.js
@@ -47,7 +47,15 @@ test('it calculates cwlObjectValue', function(assert) {
 
 test('it extracts sample names', function(assert) {
   assert.equal(extractSampleName('SA1234_XYZ_R2.fastq.gz'),'SA1234'); // Typical _ delimiter and . extension
-  assert.equal(extractSampleName('ABC.D_E_F.fastq'),'ABC'); // Ignores _ delimiter after . extension
+  assert.equal(extractSampleName('ABC.D_E_F.fastq'),'ABC.D'); // Ignores after _
   assert.equal(extractSampleName('ABC-DEF', '-'), 'ABC'); // Uses custom delimiter
-  assert.equal(extractSampleName('ABC-DEF'), 'ABC-DEF'); // Returns original string when no _ or .
+  assert.equal(extractSampleName('ABC-DEF'), 'ABC-DEF'); // Returns original string when no _
+});
+
+test('It recalculates sample name as files are added', function(assert) {
+  let fileItemList = FASTQFileItemList.create();
+  fileItemList.addFileItem(makeMockFileItem('AB1234_L001_R1.fastq'));
+  assert.equal(fileItemList.get('fastqFilePairs')[0].get('name'), 'AB1234');
+  fileItemList.addFileItem(makeMockFileItem('AB4567_L001_R1.fastq'));
+  assert.equal(fileItemList.get('fastqFilePairs')[0].get('name'), 'AB');
 });

--- a/tests/unit/utils/fastq-file-item-list-test.js
+++ b/tests/unit/utils/fastq-file-item-list-test.js
@@ -19,13 +19,13 @@ function makeMockFileItem(name) {
 
 test('it calculates fastqFilePairs', function(assert) {
   let fileItemList = FASTQFileItemList.create();
-  fileItemList.addFileItem(makeMockFileItem('abc1'));
-  fileItemList.addFileItem(makeMockFileItem('abc2'));
-  fileItemList.addFileItem(makeMockFileItem('def1'));
-  fileItemList.addFileItem(makeMockFileItem('def2'));
+  fileItemList.addFileItem(makeMockFileItem('abc_1'));
+  fileItemList.addFileItem(makeMockFileItem('abc_2'));
+  fileItemList.addFileItem(makeMockFileItem('def_1'));
+  fileItemList.addFileItem(makeMockFileItem('def_2'));
   const expectedPairs = [
-    {name: 'abc', file1: {name: 'abc1', kind: 'dds-file'}, file2: {name: 'abc2', kind: 'dds-file'}},
-    {name: 'def', file1: {name: 'def1', kind: 'dds-file'}, file2: {name: 'def2', kind: 'dds-file'}}
+    {name: 'abc', file1: {name: 'abc_1', kind: 'dds-file'}, file2: {name: 'abc_2', kind: 'dds-file'}},
+    {name: 'def', file1: {name: 'def_1', kind: 'dds-file'}, file2: {name: 'def_2', kind: 'dds-file'}}
     ];
   const calculatedPairs = fileItemList.get('fastqFilePairs');
   assert.equal(JSON.stringify(calculatedPairs), JSON.stringify(expectedPairs))
@@ -33,31 +33,38 @@ test('it calculates fastqFilePairs', function(assert) {
 
 test('it calculates cwlObjectValue', function(assert) {
   let fileItemList = FASTQFileItemList.create();
-  fileItemList.addFileItem(makeMockFileItem('abc1'));
-  fileItemList.addFileItem(makeMockFileItem('abc2'));
-  fileItemList.addFileItem(makeMockFileItem('def1'));
-  fileItemList.addFileItem(makeMockFileItem('def2'));
+  fileItemList.addFileItem(makeMockFileItem('abc_1'));
+  fileItemList.addFileItem(makeMockFileItem('abc_2'));
+  fileItemList.addFileItem(makeMockFileItem('def_1'));
+  fileItemList.addFileItem(makeMockFileItem('def_2'));
   const expectedCWLObjectValue = [
-    {name: 'abc', file1: {class: 'File', path: 'abc1'}, file2: {class: 'File', path: 'abc2'}},
-    {name: 'def', file1: {class: 'File', path: 'def1'}, file2: {class: 'File', path: 'def2'}},
+    {name: 'abc', file1: {class: 'File', path: 'abc_1'}, file2: {class: 'File', path: 'abc_2'}},
+    {name: 'def', file1: {class: 'File', path: 'def_1'}, file2: {class: 'File', path: 'def_2'}},
   ];
   const calculatedCWLObjectValue = fileItemList.get('cwlObjectValue');
   assert.equal(JSON.stringify(calculatedCWLObjectValue), JSON.stringify(expectedCWLObjectValue))
 });
 
-test('it extracts sample names', function(assert) {
-  assert.equal(extractSampleName('SA1234_XYZ_R2.fastq.gz'),'SA1234'); // Typical _ delimiter and . extension
-  assert.equal(extractSampleName('ABC.D_E_F.fastq'),'ABC.D'); // Ignores after _
-  assert.equal(extractSampleName('ABC-DEF', '-'), 'ABC'); // Uses custom delimiter
-  assert.equal(extractSampleName('ABC-DEF'), 'ABC-DEF'); // Returns original string when no _
+test('it extracts sample names with delimiter', function(assert) {
+  const delimiters = [' ','_', '-'];
+  assert.equal(extractSampleName('SA1234_XYZ_R2.fastq.gz', delimiters),'SA1234');
+  assert.equal(extractSampleName('SA1234-XYZ_R2.fastq.gz', delimiters),'SA1234');
+  assert.equal(extractSampleName('SA1234 XYZ_R2.fastq.gz', delimiters),'SA1234');
 });
 
 test('It recalculates sample name as files are added', function(assert) {
   let fileItemList = FASTQFileItemList.create();
   fileItemList.addFileItem(makeMockFileItem('AB1234_L001_R1.fastq'));
   assert.equal(fileItemList.get('fastqFilePairs')[0].get('name'), ''); // initially no common prefix since only one file
-  fileItemList.addFileItem(makeMockFileItem('AB4567_L001_R1.fastq'));
-  assert.equal(fileItemList.get('fastqFilePairs')[0].get('name'), 'AB');
+  fileItemList.addFileItem(makeMockFileItem('AB1234_L001_R2.fastq'));
+  assert.equal(fileItemList.get('fastqFilePairs')[0].get('name'), 'AB1234');
+});
+
+test('It sets empty sample name when no match before delimiter', function(assert) {
+  let fileItemList = FASTQFileItemList.create();
+  fileItemList.addFileItem(makeMockFileItem('AB1234_L001_R1.fastq'));
+  fileItemList.addFileItem(makeMockFileItem('AB1235_L001_R2.fastq'));
+  assert.equal(fileItemList.get('fastqFilePairs')[0].get('name'), '');
 });
 
 test('it calculates isComplete', function(assert) {

--- a/tests/unit/utils/fastq-file-item-list-test.js
+++ b/tests/unit/utils/fastq-file-item-list-test.js
@@ -1,4 +1,4 @@
-import { FASTQFileItemList, extractSampleName } from 'bespin-ui/utils/fastq-file-item-list';
+import { FASTQFileItemList, extractSampleName, splitMultipleSeparators } from 'bespin-ui/utils/fastq-file-item-list';
 import { module, test } from 'qunit';
 import Ember from 'ember';
 
@@ -112,4 +112,31 @@ test('it calculates hasUniqueSampleNames', function(assert) {
     fileItemList.addFileItem(makeMockFileItem('sample1_F'));
     assert.notOk(fileItemList.get('hasUniqueSampleNames'));
   });
+});
+
+test('splitMultipleSeparators splits on multiple separators', function(assert) {
+  const name = 'A_B-C.D';
+  const separators = ['_','-','.'];
+  const split = splitMultipleSeparators(name, separators);
+  assert.deepEqual(split, ['A','B','C','D']);
+});
+
+test('splitMultipleSeparators splits on single separator', function(assert) {
+  const name = 'A+B+C+D';
+  const separators = ['+'];
+  const split = splitMultipleSeparators(name, separators);
+  assert.deepEqual(split, ['A','B','C','D']);
+});
+
+test('splitMultipleSeparators returns original string with no separator', function(assert) {
+  const name = 'A+B+C+D';
+  const separators = [];
+  const split = splitMultipleSeparators(name, separators);
+  assert.deepEqual(split, ['A+B+C+D']);
+});
+
+test('splitMultipleSeparators handles null separators field', function(assert) {
+  const name = 'A+B+C+D';
+  const split = splitMultipleSeparators(name);
+  assert.deepEqual(split, ['A+B+C+D']);
 });

--- a/tests/unit/utils/fastq-file-item-list-test.js
+++ b/tests/unit/utils/fastq-file-item-list-test.js
@@ -89,3 +89,27 @@ test('it calculates isComplete', function(assert) {
     assert.ok(fileItemList.get('isComplete')); // complete
   });
 });
+
+test('it calculates hasUniqueSampleNames', function(assert) {
+  let fileItemList = FASTQFileItemList.create();
+  Ember.run(() => {
+    // First, check an empty list
+    assert.equal(fileItemList.get('fastqFilePairs.length'), 0);
+    assert.ok(fileItemList.get('hasUniqueSampleNames')); // Empty list should count as unique names
+
+    // Add two files to make one sample
+    fileItemList.addFileItem(makeMockFileItem('sample1_A'));
+    fileItemList.addFileItem(makeMockFileItem('sample1_B'));
+    assert.ok(fileItemList.get('hasUniqueSampleNames'));
+
+    // Add two more files to make another sample
+    fileItemList.addFileItem(makeMockFileItem('sample2_C'));
+    fileItemList.addFileItem(makeMockFileItem('sample2_D'));
+    assert.ok(fileItemList.get('hasUniqueSampleNames'));
+
+    // Add another file with a conflicting sample name
+    fileItemList.addFileItem(makeMockFileItem('sample1_F'));
+    fileItemList.addFileItem(makeMockFileItem('sample1_F'));
+    assert.notOk(fileItemList.get('hasUniqueSampleNames'));
+  });
+});

--- a/tests/unit/utils/file-item-list-test.js
+++ b/tests/unit/utils/file-item-list-test.js
@@ -156,9 +156,11 @@ test('it extracts common prefixes from pairs of file names', function(assert) {
   assert.equal(commonPrefix('abd', 'abc'), 'ab');
   assert.equal(commonPrefix('abc', 'abcdefg'), 'abc');
   assert.equal(commonPrefix('abcdefg', 'abc'), 'abc');
-  assert.equal(commonPrefix('abc','def'), 'abc+def');
-  assert.equal(commonPrefix('def','abc'), 'def+abc');
-  assert.equal(commonPrefix('',null), '+');
+  assert.equal(commonPrefix('abc','def'), '');
+  assert.equal(commonPrefix('def','abc'), '');
+  assert.equal(commonPrefix('',null), '');
+  assert.equal(commonPrefix(null,''), '');
+  assert.equal(commonPrefix(null,null), '');
   assert.equal(commonPrefix('joint_genotype_raw_variants.g.vcf','joint_genotype_raw_variants.g.vcf.idx'), 'joint_genotype_raw_variants.g.vcf');
   assert.equal(commonPrefix('joint_genotype_raw_variants.g.vcf.idx','joint_genotype_raw_variants.g.vcf'), 'joint_genotype_raw_variants.g.vcf');
   assert.equal(commonPrefix('joint_genotype_raw_variants.g.vcf.idx','joint_genotype_raw_variants.g.vcf.idx'), 'joint_genotype_raw_variants.g.vcf.idx');

--- a/tests/unit/utils/file-item-list-test.js
+++ b/tests/unit/utils/file-item-list-test.js
@@ -153,6 +153,7 @@ test('it falls back to simple inclusion when ddsFile not present', function(asse
 
 test('it extracts common prefixes from pairs of file names', function(assert) {
   assert.equal(commonPrefix('abc', 'abd'), 'ab');
-  assert.equal(commonPrefix('abc','def'), '');
-  assert.equal(commonPrefix('',null), '');
+  assert.equal(commonPrefix('abc','def'), 'abc+def');
+  assert.equal(commonPrefix('',null), '+');
+  assert.equal(commonPrefix('joint_genotype_raw_variants.g.vcf','joint_genotype_raw_variants.g.vcf.idx'), 'joint_genotype_raw_variants.g.vcf');
 });

--- a/tests/unit/utils/file-item-list-test.js
+++ b/tests/unit/utils/file-item-list-test.js
@@ -1,4 +1,4 @@
-import { FileItemList, FileItem } from 'bespin-ui/utils/file-item-list';
+import { FileItemList, FileItem, commonPrefix } from 'bespin-ui/utils/file-item-list';
 import { module, test } from 'qunit';
 import Ember from 'ember';
 
@@ -149,4 +149,10 @@ test('it falls back to simple inclusion when ddsFile not present', function(asse
   assert.notEqual(f1, f2);
   const fileItemList = FileItemList.create({content: [f1]});
   assert.notOk(fileItemList.includesFileItem(f2));
+});
+
+test('it extracts common prefixes from pairs of file names', function(assert) {
+  assert.equal(commonPrefix('abc', 'abd'), 'ab');
+  assert.equal(commonPrefix('abc','def'), '');
+  assert.equal(commonPrefix('',null), '');
 });

--- a/tests/unit/utils/file-item-list-test.js
+++ b/tests/unit/utils/file-item-list-test.js
@@ -153,7 +153,13 @@ test('it falls back to simple inclusion when ddsFile not present', function(asse
 
 test('it extracts common prefixes from pairs of file names', function(assert) {
   assert.equal(commonPrefix('abc', 'abd'), 'ab');
+  assert.equal(commonPrefix('abd', 'abc'), 'ab');
+  assert.equal(commonPrefix('abc', 'abcdefg'), 'abc');
+  assert.equal(commonPrefix('abcdefg', 'abc'), 'abc');
   assert.equal(commonPrefix('abc','def'), 'abc+def');
+  assert.equal(commonPrefix('def','abc'), 'def+abc');
   assert.equal(commonPrefix('',null), '+');
   assert.equal(commonPrefix('joint_genotype_raw_variants.g.vcf','joint_genotype_raw_variants.g.vcf.idx'), 'joint_genotype_raw_variants.g.vcf');
+  assert.equal(commonPrefix('joint_genotype_raw_variants.g.vcf.idx','joint_genotype_raw_variants.g.vcf'), 'joint_genotype_raw_variants.g.vcf');
+  assert.equal(commonPrefix('joint_genotype_raw_variants.g.vcf.idx','joint_genotype_raw_variants.g.vcf.idx'), 'joint_genotype_raw_variants.g.vcf.idx');
 });


### PR DESCRIPTION
- Adds a component, `fastq-file-pair-list`, for providing arrays of NamedFASTQFilePairType (https://github.com/Duke-GCB/bespin-cwl/pull/41). This component subclasses the generic `file-group-list`.
- Adds a data structure, `fastq-file-item-list` that encapsulates named pairs of samples. This subclasses `file-item-list`
- Implements simple name parsing logic from pairs of files (commonPrefix)
- Reports errors for no files chosen, undetectable sample names, incomplete pairs, and non-unique sample names
- `build-answer-set` now passes down an `AnswerFormErrors` object, allowing a component to communicate errors back to the route itself, display them, and prevent saving all of the job ojects.

Fixes #85 

Note: 

- The component expects `format: http://edamontology.org/format_1930` (FASTQ), to be specified in the CWL type from the API, I still need to address this, since the type is not part of the definition.
