### PR TITLE
Adds component to fill in string values in user CWL

### DIFF
--- a/app/components/questionnaire/string-field.js
+++ b/app/components/questionnaire/string-field.js
@@ -15,34 +15,37 @@ const StringField = Ember.Component.extend({
       return null;
     }
   }),
-  value: null,
+  stringValue: null,
   answerFormErrors: null,
   fieldErrors: Ember.computed('answerFormErrors.errors.[]', 'fieldName', function() {
     return this.get('answerFormErrors.errors').filterBy('field', this.get('fieldName'));
   }),
-  validityDidChange: Ember.on('init', Ember.observer('answerFormErrors', 'value', function() {
+  validityDidChange: Ember.on('init', Ember.observer('answerFormErrors', 'stringValue', function() {
     const answerFormErrors = this.get('answerFormErrors');
     if(!answerFormErrors) {
       // We have not answerFormErrors object, bail out
       return;
     }
     const fieldName = this.get('fieldName');
-    const value = this.get('value');
-    if(Ember.isEmpty(value)) {
+    const stringValue = this.get('stringValue');
+    if(Ember.isEmpty(stringValue)) {
       answerFormErrors.setError(fieldName, 'Please enter a value for this field.');
     } else {
       // All Good!
       answerFormErrors.clearError(fieldName);
     }
   })),
-  answer: Ember.computed('fieldName','value', function() {
+  answer: Ember.computed('fieldName', 'stringValue', function() {
     const fieldName = this.get('fieldName');
-    const value = this.get('value');
+    const stringValue = this.get('stringValue');
     const answer = Ember.Object.create();
-    if(fieldName && value) {
-      answer.set(fieldName, value);
+    if(fieldName && stringValue) {
+      answer.set(fieldName, stringValue);
     }
     return answer;
+  }),
+  valueDidChange: Ember.observer('stringValue', function() {
+    this.sendAction('answerChanged', this);
   })
 });
 

--- a/app/components/questionnaire/string-field.js
+++ b/app/components/questionnaire/string-field.js
@@ -1,0 +1,53 @@
+import Ember from 'ember';
+
+const StringField = Ember.Component.extend({
+  /**
+   * Encapsulates a text field for a single string answer
+   */
+  tagName: 'div',
+  classNames: ['row','string-field'],
+  fieldName: null,
+  displayFieldName: Ember.computed('fieldName', function() {
+    const fieldName = this.get('fieldName');
+    if(fieldName) {
+      return fieldName.capitalize();
+    } else {
+      return null;
+    }
+  }),
+  value: null,
+  answerFormErrors: null,
+  fieldErrors: Ember.computed('answerFormErrors.errors.[]', 'fieldName', function() {
+    return this.get('answerFormErrors.errors').filterBy('field', this.get('fieldName'));
+  }),
+  validityDidChange: Ember.on('init', Ember.observer('answerFormErrors', 'value', function() {
+    const answerFormErrors = this.get('answerFormErrors');
+    if(!answerFormErrors) {
+      // We have not answerFormErrors object, bail out
+      return;
+    }
+    const fieldName = this.get('fieldName');
+    const value = this.get('value');
+    if(Ember.isEmpty(value)) {
+      answerFormErrors.setError(fieldName, 'Please enter a value for this field.');
+    } else {
+      // All Good!
+      answerFormErrors.clearError(fieldName);
+    }
+  })),
+  answer: Ember.computed('fieldName','value', function() {
+    const fieldName = this.get('fieldName');
+    const value = this.get('value');
+    const answer = Ember.Object.create();
+    if(fieldName && value) {
+      answer.set(fieldName, value);
+    }
+    return answer;
+  })
+});
+
+StringField.reopenClass({
+  positionalParams: ['fieldName','answerChanged']
+});
+
+export default StringField;

--- a/app/models/job-questionnaire.js
+++ b/app/models/job-questionnaire.js
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import Ember from 'ember';
 
 export default DS.Model.extend({
   name: DS.attr('string'),
@@ -7,5 +8,6 @@ export default DS.Model.extend({
   systemJobOrderJson: DS.attr('json-object'), // This is JSON
   userFieldsJson: DS.attr('json-array'), // This is a JSON Array
   vmFlavor: DS.belongsTo('vm-flavor'),
-  vmProject: DS.belongsTo('vm-project')
+  vmProject: DS.belongsTo('vm-project'),
+  displayName: Ember.computed.alias('name')
 });

--- a/app/templates/components/questionnaire/answer-form.hbs
+++ b/app/templates/components/questionnaire/answer-form.hbs
@@ -1,5 +1,7 @@
 {{questionnaire/answer-form-header answerSet.questionnaire}}
+<h4>Job Information</h4>
 {{questionnaire/job-name answerSet}}
 {{questionnaire/fund-code answerSet}}
+<h4>Workflow-specific Details</h4>
 {{questionnaire/answer-form-list answerSet answerFormErrors}}
 {{yield}}

--- a/app/templates/components/questionnaire/string-field.hbs
+++ b/app/templates/components/questionnaire/string-field.hbs
@@ -1,0 +1,7 @@
+<div class="col-md-12">
+  <label for="{{concat elementId '-stringField'}}">{{ displayFieldName }}</label>
+  {{input class='form-control string-field-input' id=(concat elementId '-stringField')  value=value}}
+  {{#if answerFormErrors.show}}
+    {{error-panel errors=fieldErrors}}
+  {{/if}}
+</div>

--- a/app/templates/components/questionnaire/string-field.hbs
+++ b/app/templates/components/questionnaire/string-field.hbs
@@ -1,6 +1,10 @@
 <div class="col-md-12">
-  <label for="{{concat elementId '-stringField'}}">{{ displayFieldName }}</label>
-  {{input class='form-control string-field-input' id=(concat elementId '-stringField') value=stringValue}}
+{{#bs-form as |form|}}
+  {{#form.group class='string-field-group'}}
+    <label for="{{concat elementId '-stringField'}}">{{ displayFieldName }}</label>
+    {{input class='form-control string-field-input' id=(concat elementId '-stringField') value=stringValue}}
+    {{/form.group}}
+  {{/bs-form}}
   {{#if answerFormErrors.show}}
     {{error-panel errors=fieldErrors}}
   {{/if}}

--- a/app/templates/components/questionnaire/string-field.hbs
+++ b/app/templates/components/questionnaire/string-field.hbs
@@ -1,6 +1,6 @@
 <div class="col-md-12">
   <label for="{{concat elementId '-stringField'}}">{{ displayFieldName }}</label>
-  {{input class='form-control string-field-input' id=(concat elementId '-stringField')  value=value}}
+  {{input class='form-control string-field-input' id=(concat elementId '-stringField') value=stringValue}}
   {{#if answerFormErrors.show}}
     {{error-panel errors=fieldErrors}}
   {{/if}}

--- a/app/utils/component-settings.js
+++ b/app/utils/component-settings.js
@@ -27,6 +27,12 @@ const ComponentSettings = [
         groupName: 'Sample'
       }
     ]
+  },
+  {
+    // String field
+    cwlType: 'string', // Defined in CWL
+    name: 'string-field',  // Component to render
+    formats: [], // No formats for a string
   }
 ];
 

--- a/tests/integration/components/questionnaire/string-field-test.js
+++ b/tests/integration/components/questionnaire/string-field-test.js
@@ -1,0 +1,47 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+moduleForComponent('questionnaire/string-field', 'Integration | Component | questionnaire/string field', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  this.set('fieldName', 'field');
+  this.render(hbs`{{questionnaire/string-field fieldName}}`);
+  assert.equal(this.$().text().trim(), 'Field');
+});
+
+test('it shows/hides errors based on answerFormErrors.show', function(assert) {
+  this.set('fieldName', 'field-name');
+  this.set('answerFormErrors', Ember.Object.create({
+    show: true,
+    errors: [{field: 'field-name', message: 'Error Message'}],
+    setError() { }
+  }));
+    this.render(hbs`{{questionnaire/string-field fieldName=fieldName answerFormErrors=answerFormErrors}}`);
+  assert.equal(this.$('.error-panel').text().trim(), 'Error Message');
+
+  this.set('answerFormErrors.show', false);
+    this.render(hbs`{{questionnaire/string-field fieldName=fieldName answerFormErrors=answerFormErrors}}`);
+  assert.equal(this.$('.error-panel').text().trim(), '');
+});
+
+test('it correctly observes error array', function(assert) {
+  const errors = Ember.Object.create({
+    show: true,
+    errors: [{field: 'field-name', message: 'Empty'}],
+    setError() { }
+  });
+  this.set('answerFormErrors', errors);
+  this.set('fieldName', 'field-name');
+  Ember.run(() => {
+    // Initially empty
+    this.render(hbs`{{questionnaire/string-field fieldName=fieldName answerFormErrors=answerFormErrors}}`);
+    assert.equal(this.$('.error-panel').text().trim(), 'Empty');
+
+    // Now replace the errors and verify the new error is displayed
+    this.set('answerFormErrors.errors', [{field: 'field-name', message: 'Incomplete'}]);
+    assert.equal(this.$('.error-panel').text().trim(), 'Incomplete');
+  });
+});

--- a/tests/unit/components/questionnaire/string-field-test.js
+++ b/tests/unit/components/questionnaire/string-field-test.js
@@ -19,7 +19,7 @@ test('it records error with empty string', function(assert) {
 
   this.subject({
     fieldName: 'string-field1',
-    value: '',
+    stringValue: '',
     answerFormErrors: mockErrors
   });
 });
@@ -37,7 +37,7 @@ test('it records no error when everything good', function(assert) {
 
   this.subject({
     fieldName: 'string-field2',
-    value: 'Something',
+    stringValue: 'Something',
     answerFormErrors: mockErrors
   });
 });
@@ -48,6 +48,6 @@ test('it computes an answer object from the fieldName and value', function(asser
   assert.notOk(stringField.get('answer').get(fieldName));
   stringField.set('fieldName',fieldName);
   assert.notOk(stringField.get('answer').get(fieldName));
-  stringField.set('value','value123');
+  stringField.set('stringValue','value123');
   assert.equal(stringField.get('answer').get('field3'), 'value123');
 });

--- a/tests/unit/components/questionnaire/string-field-test.js
+++ b/tests/unit/components/questionnaire/string-field-test.js
@@ -1,0 +1,53 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
+
+moduleForComponent('questionnaire/string-field', 'Unit | Component | questionnaire/string field', {
+  unit: true
+});
+
+test('it records error with empty string', function(assert) {
+  assert.expect(2);
+  const mockErrors = Ember.Object.create({
+    setError(fieldName, errorText) {
+      assert.equal(fieldName, 'string-field1');
+      assert.equal(errorText, 'Please enter a value for this field.');
+    },
+    clearError(/* fieldName */) {
+      assert.notOk(true); // clearError should not be called
+    }
+  });
+
+  this.subject({
+    fieldName: 'string-field1',
+    value: '',
+    answerFormErrors: mockErrors
+  });
+});
+
+test('it records no error when everything good', function(assert) {
+  assert.expect(1);
+  const mockErrors = Ember.Object.create({
+    setError(/* fieldName, errorText */) {
+      assert.notOk(true); // Should not call this!
+    },
+    clearError(fieldName) {
+      assert.equal(fieldName, 'string-field2');
+    }
+  });
+
+  this.subject({
+    fieldName: 'string-field2',
+    value: 'Something',
+    answerFormErrors: mockErrors
+  });
+});
+
+test('it computes an answer object from the fieldName and value', function(assert) {
+  const fieldName = 'field3';
+  const stringField = this.subject();
+  assert.notOk(stringField.get('answer').get(fieldName));
+  stringField.set('fieldName',fieldName);
+  assert.notOk(stringField.get('answer').get(fieldName));
+  stringField.set('value','value123');
+  assert.equal(stringField.get('answer').get('field3'), 'value123');
+});


### PR DESCRIPTION
Specific case: `library` is being removed from the system fields (https://github.com/Duke-GCB/bespin-cwl/pull/42), so the UI must be able to provide answers for string variables in the userJobOrderJson