### PR TITLE
fix bug passing wrong object to readme link

### DIFF
--- a/app/templates/components/job-detail-row.hbs
+++ b/app/templates/components/job-detail-row.hbs
@@ -5,7 +5,7 @@
 <td class="job-detail-cell-status">{{decode-job-state job.state}}</td>
 <td class="job-detail-cell-created">{{job.created}}</td>
 <td class="job-detail-cell-updated">{{job.lastUpdated}}</td>
-<td class="job-detail-cell-readme">{{#if job.isFinished}}{{#link-to "jobs.readme" job.outputProject}}README{{/link-to}}{{/if}}</td>
+<td class="job-detail-cell-readme">{{#if job.isFinished}}{{#link-to "jobs.readme" job}}README{{/link-to}}{{/if}}</td>
 <td class="job-detail-cell-delete">{{#if job.isDeletable}}
   {{modal-confirmation
     title=modalConfirmationTitle

--- a/tests/integration/components/job-detail-row-test.js
+++ b/tests/integration/components/job-detail-row-test.js
@@ -2,7 +2,10 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('job-detail-row', 'Integration | Component | job detail row', {
-  integration: true
+  integration: true,
+  setup() {
+    this.container.lookup('router:main').setupRouter();
+  }
 });
 
 test('it renders', function(assert) {
@@ -19,9 +22,10 @@ test('it renders', function(assert) {
 });
 
 test('it renders readme link for finished jobs', function(assert) {
-  this.set('job', {isFinished: true});
+  this.set('job', {id: 123, isFinished: true});
   this.render(hbs`{{job-detail-row job}}`);
   assert.equal(this.$('.job-detail-cell-readme a').text().trim(), 'README', 'Should show readme link for finished job');
+  assert.equal(this.$('.job-detail-cell-readme a').attr('href'), '/jobs/123/readme');
 });
 
 test('it hides readme link for finished jobs', function(assert) {


### PR DESCRIPTION
We were passing job.outputProject to a link-to that expected a job.

https://github.com/Duke-GCB/bespin-ui/blob/5f540c1f696fd2b1d7884d7c144af9a1350f590e/app/templates/components/job-detail-row.hbs#L8

https://github.com/Duke-GCB/bespin-ui/blob/5f540c1f696fd2b1d7884d7c144af9a1350f590e/app/routes/jobs/readme.js#L3-L9

https://github.com/Duke-GCB/bespin-ui/blob/5f540c1f696fd2b1d7884d7c144af9a1350f590e/app/router.js#L33-L35

Had to add special logic to the test to be able to read the `href` value from the `link-to`.
https://stackoverflow.com/questions/32130798/ember-component-integration-tests-link-to-href-empty/33047937

Fixes #134