### PR TITLE
Update workflow-version-link to not prefix versions with v

### DIFF
--- a/app/templates/components/workflow-version-link.hbs
+++ b/app/templates/components/workflow-version-link.hbs
@@ -1,4 +1,4 @@
 {{#link-to "workflows.versions.show" workflowVersion.workflow workflowVersion}}
-  <span class="workflow-version-link-text">v{{workflowVersion.version}}</span>
+  <span class="workflow-version-link-text">{{workflowVersion.version}}</span>
 {{/link-to}}
 {{yield}}

--- a/app/templates/components/workflows/workflow-version-detail.hbs
+++ b/app/templates/components/workflows/workflow-version-detail.hbs
@@ -8,7 +8,7 @@
         {{#link-to "workflows.versions.show" workflowVersion.workflow workflowVersion}}More...{{/link-to}}
       {{/unless}}
         <a class="workflow-version-detail-download-cwl-url pull-right btn btn-primary"
-           href="{{workflowVersion.url}}" role="button">Download CWL</a>
+           href="{{workflowVersion.url}}" role="button">Download Workflow</a>
         {{yield}}
     </div>
 </div>

--- a/tests/integration/components/job-detail-row-test.js
+++ b/tests/integration/components/job-detail-row-test.js
@@ -10,7 +10,7 @@ moduleForComponent('job-detail-row', 'Integration | Component | job detail row',
 
 test('it renders', function(assert) {
   const job = {id:1,name:'job', workflowVersion: {
-    version: 23,
+    version: 'v2.3.0',
     workflow: {name:'RNA-seq'}},
     outputProject: '{"name":"results","project_id":"ab-12-cd-34"}'
   };
@@ -19,7 +19,7 @@ test('it renders', function(assert) {
 
   assert.equal(this.$('.job-detail-cell-id').text().trim(), '1');
   assert.equal(this.$('.job-detail-cell-name').text().trim(), 'job');
-  assert.equal(this.$('.job-detail-cell-workflow-name').text().trim().replace(/ /g, ''), 'RNA-seq-v23');
+  assert.equal(this.$('.job-detail-cell-workflow-name').text().trim().replace(/ /g, ''), 'RNA-seq-v2.3.0');
   assert.equal(this.$('.job-detail-cell-readme').text().trim(), '', 'Should not show readme link unless job is finished');
   // Without routing, the link-to doesn't generate a href
   assert.equal(this.$('a.job-show-link').length, 1, 'Should generate a link for the job details');

--- a/tests/integration/components/jobs/workflow-version-card-test.js
+++ b/tests/integration/components/jobs/workflow-version-card-test.js
@@ -10,7 +10,7 @@ test('it renders', function(assert) {
 
   const workflowVersion = {
     workflow: {name: 'Exome Seq'},
-    version: '1',
+    version: 'v1.0.0',
     disableUi: false,
   };
   this.set('workflowVersion', workflowVersion);
@@ -20,7 +20,7 @@ test('it renders', function(assert) {
   this.render(hbs`{{jobs/workflow-version-card workflowVersion=workflowVersion onPicked=(action onPicked)}}`);
 
   assert.equal(this.$('.jobs-workflow-version-card-title').text().trim(), 'Exome Seq');
-  assert.equal(this.$('.workflow-version-link-text').text().trim(), 'v1');
+  assert.equal(this.$('.workflow-version-link-text').text().trim(), 'v1.0.0');
   assert.equal(this.$('input[name=selectedItem]').attr('type'), 'radio');
   this.$('input[name=selectedItem]').click();
 

--- a/tests/integration/components/workflow-version-link-test.js
+++ b/tests/integration/components/workflow-version-link-test.js
@@ -12,7 +12,7 @@ moduleForComponent('workflow-version-link', 'Integration | Component | workflow 
 test('it renders the workflowVersion version number and a link', function(assert) {
   this.set('workflowVersion', Ember.Object.create({
     id: 111,
-    version: 222,
+    version: 'v2.0.0',
     workflow: Ember.Object.create({
       id: 333
     })
@@ -21,5 +21,5 @@ test('it renders the workflowVersion version number and a link', function(assert
   this.render(hbs`{{workflow-version-link workflowVersion=workflowVersion}}`);
 
   assert.equal(this.$('a').attr('href').trim(), '/workflows/333/versions/111');
-  assert.equal(this.$('.workflow-version-link-text').text().trim(), 'v222');
+  assert.equal(this.$('.workflow-version-link-text').text().trim(), 'v2.0.0');
 });


### PR DESCRIPTION
- version is now treated as a string
- Also updates Download CWL button to Download Workflow

Fixes #147 