### PR TITLE
Sort workflow versions based on SemVer parts

### DIFF
--- a/app/components/workflows/workflow-detail.js
+++ b/app/components/workflows/workflow-detail.js
@@ -3,9 +3,8 @@ import Ember from 'ember';
 const WorkflowDetail = Ember.Component.extend({
   classNames: ['workflow-detail'],
   workflow: null,
-  sortedVersionsNewestFirst: Ember.computed('workflow.versions[]', function() {
-    const versions = this.get('workflow.versions').sortBy('version').reverse();
-    return versions;
+  sortedVersionsNewestFirst: Ember.computed('workflow.versions.@each.versionSort', function() {
+    return this.get('workflow.versions').sortBy('versionSort').reverse();
   })
 });
 

--- a/app/controllers/jobs/new/select-workflow-version.js
+++ b/app/controllers/jobs/new/select-workflow-version.js
@@ -2,6 +2,9 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   workflowVersion: null,
+  sortedVersions: Ember.computed('model.versions.@each.versionSort', function() {
+    return this.get('model.versions').sortBy('versionSort');
+  }),
   actions: {
     back() {
       this.transitionToRoute('jobs.new.select-workflow');

--- a/app/models/workflow-version.js
+++ b/app/models/workflow-version.js
@@ -1,6 +1,8 @@
 import DS from 'ember-data';
 import Ember from 'ember';
 
+const VERSION_SORT_LPAD_AMT = 10;
+
 export default DS.Model.extend({
   workflow: DS.belongsTo('workflow'),
   description: DS.attr('string'),
@@ -24,5 +26,14 @@ export default DS.Model.extend({
     const version = this.get('version');
     return `${tag}/${version}`;
   }),
-
+  versionSort: Ember.computed('version', function () {
+    const version = this.get('version');
+    if (version) {
+      // Splits semantic versioning string and left pad parts.
+      // Follows bespin-api's WorkflowVersion.sort_workflow_then_version_key method.
+      const parts = version.split(/\.|-/);
+      return parts.map(x => x.padStart(VERSION_SORT_LPAD_AMT, '0'));
+    }
+    return null;
+  })
 });

--- a/app/models/workflow-version.js
+++ b/app/models/workflow-version.js
@@ -1,5 +1,6 @@
 import DS from 'ember-data';
 import Ember from 'ember';
+import { padStart } from 'ember-pad/utils/pad';
 
 const VERSION_SORT_LPAD_AMT = 10;
 
@@ -32,7 +33,7 @@ export default DS.Model.extend({
       // Splits semantic versioning string and left pad parts.
       // Follows bespin-api's WorkflowVersion.sort_workflow_then_version_key method.
       const parts = version.split(/\.|-/);
-      return parts.map(x => x.padStart(VERSION_SORT_LPAD_AMT, '0'));
+      return parts.map(x => padStart(x, VERSION_SORT_LPAD_AMT));
     }
     return null;
   })

--- a/app/templates/jobs/new/select-workflow-version.hbs
+++ b/app/templates/jobs/new/select-workflow-version.hbs
@@ -3,7 +3,7 @@
     {{#form.group  class='job-kind'}}
         <label class="control-label">Workflow version:</label>
         <div class="row">
-          {{#each model.versions as |version| }}
+          {{#each sortedVersions as |version| }}
             {{jobs/workflow-version-card workflowVersion=version onPicked=(action 'setWorkflowVersion')}}
           {{/each}}
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4380,7 +4380,7 @@
           "integrity": "sha1-6S0sb3f9RtW/ULYQ0orTF1UFTQs=",
           "dev": true,
           "requires": {
-            "rsvp": "3.2.1"
+            "rsvp": "~3.2.1"
           }
         },
         "rsvp": {
@@ -4746,6 +4746,15 @@
           "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
           "dev": true
         }
+      }
+    },
+    "ember-pad": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/ember-pad/-/ember-pad-1.2.3.tgz",
+      "integrity": "sha512-Dpaqv40nDCIHoxp2YEpxz7RcQaYHS0L8fs91sGG7YkCUHsNjSBcyrABighnofWMBCcaJD7f9mx+fZPdGjdJjxA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^6.6.0"
       }
     },
     "ember-popper": {
@@ -6398,7 +6407,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "strip-ansi": {
@@ -6696,7 +6705,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -6747,7 +6757,8 @@
         "balanced-match": {
           "version": "0.4.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -6762,6 +6773,7 @@
           "version": "0.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -6770,6 +6782,7 @@
           "version": "2.10.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -6778,6 +6791,7 @@
           "version": "1.1.7",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
@@ -6786,7 +6800,8 @@
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -6803,12 +6818,14 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -6816,22 +6833,26 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x"
           }
@@ -6871,7 +6892,8 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -6903,7 +6925,8 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -6925,12 +6948,14 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -6986,6 +7011,7 @@
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -6998,7 +7024,8 @@
         "graceful-fs": {
           "version": "4.1.11",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "har-schema": {
           "version": "1.0.5",
@@ -7026,6 +7053,7 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x",
             "cryptiles": "2.x.x",
@@ -7036,7 +7064,8 @@
         "hoek": {
           "version": "2.16.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -7053,6 +7082,7 @@
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -7061,7 +7091,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.4",
@@ -7073,6 +7104,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7086,7 +7118,8 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -7159,12 +7192,14 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -7173,6 +7208,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7180,12 +7216,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7240,7 +7278,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -7258,6 +7297,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7287,7 +7327,8 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "performance-now": {
           "version": "0.2.0",
@@ -7298,7 +7339,8 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -7336,6 +7378,7 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -7380,6 +7423,7 @@
           "version": "2.6.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.0.5"
           }
@@ -7387,7 +7431,8 @@
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -7411,6 +7456,7 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -7444,6 +7490,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7454,6 +7501,7 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -7468,6 +7516,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7482,6 +7531,7 @@
           "version": "2.2.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -7537,7 +7587,8 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -7566,7 +7617,8 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9454,7 +9506,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -9826,7 +9878,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -11354,7 +11406,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -11667,13 +11719,13 @@
           "integrity": "sha1-Tj4pxDO0z+pnXsg15vEjkcYf0is=",
           "dev": true,
           "requires": {
-            "lodash._escapestringchar": "2.3.0",
-            "lodash._reinterpolate": "2.3.0",
-            "lodash.defaults": "2.3.0",
-            "lodash.escape": "2.3.0",
-            "lodash.keys": "2.3.0",
-            "lodash.templatesettings": "2.3.0",
-            "lodash.values": "2.3.0"
+            "lodash._escapestringchar": "~2.3.0",
+            "lodash._reinterpolate": "~2.3.0",
+            "lodash.defaults": "~2.3.0",
+            "lodash.escape": "~2.3.0",
+            "lodash.keys": "~2.3.0",
+            "lodash.templatesettings": "~2.3.0",
+            "lodash.values": "~2.3.0"
           }
         },
         "source-map": {
@@ -11682,7 +11734,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-moment": "^7.4.1",
     "ember-number-to-human-size": "0.3.0",
+    "ember-pad": "^1.2.3",
     "ember-radio-buttons": "4.0.3",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.13.3",

--- a/tests/unit/components/workflows/workflow-detail-test.js
+++ b/tests/unit/components/workflows/workflow-detail-test.js
@@ -1,14 +1,21 @@
 import { moduleForComponent, test } from 'ember-qunit';
 
 moduleForComponent('workflows/workflow-detail', 'Unit | Component | workflows/workflow detail', {
-  unit: true
+  unit: true,
+  needs: ['model:workflow-version']
 });
 
 test('it sorts versions with newest first', function(assert) {
-  const versions = [{version:'v2'}, {version: 'v3'}, {version: 'v5'}, {version: 'v1'}, {version: 'v4'}];
+  const versions = [
+    {versionSort: '000v2'},
+    {versionSort: '000v3'},
+    {versionSort: '00v10'},
+    {versionSort: '000v5'},
+    {versionSort: '000v1'},
+    {versionSort: '000v4'}];
   const workflow = {versions: versions};
   const component = this.subject({workflow: workflow});
   const sortedVersions = component.get('sortedVersionsNewestFirst');
-  const stringVersions = sortedVersions.mapBy('version').join(',');
-  assert.equal(stringVersions, 'v5,v4,v3,v2,v1');
+  const stringVersions = sortedVersions.mapBy('versionSort').join(',');
+  assert.equal(stringVersions, '00v10,000v5,000v4,000v3,000v2,000v1');
 });

--- a/tests/unit/components/workflows/workflow-detail-test.js
+++ b/tests/unit/components/workflows/workflow-detail-test.js
@@ -1,8 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 
 moduleForComponent('workflows/workflow-detail', 'Unit | Component | workflows/workflow detail', {
-  unit: true,
-  needs: ['model:workflow-version']
+  unit: true
 });
 
 test('it sorts versions with newest first', function(assert) {

--- a/tests/unit/controllers/jobs/new/select-workflow-version-test.js
+++ b/tests/unit/controllers/jobs/new/select-workflow-version-test.js
@@ -32,3 +32,18 @@ test('it handles next action', function(assert) {
   });
   controller.send('next');
 });
+
+test('it sorts versions', function(assert) {
+  const versions = [
+    {versionSort: '000v2'},
+    {versionSort: '000v3'},
+    {versionSort: '00v10'},
+    {versionSort: '000v5'},
+    {versionSort: '000v1'},
+    {versionSort: '000v4'}];
+  const workflow = {versions: versions};
+  const component = this.subject({model: workflow});
+  const sortedVersions = component.get('sortedVersions');
+  const stringVersions = sortedVersions.mapBy('versionSort').join(',');
+  assert.equal(stringVersions, '000v1,000v2,000v3,000v4,000v5,00v10');
+});

--- a/tests/unit/models/workflow-version-test.js
+++ b/tests/unit/models/workflow-version-test.js
@@ -46,3 +46,17 @@ test('it computes versionTag', function(assert) {
   });
   assert.equal(version.get('versionTag'),'wf-tag/v3.2');
 });
+
+test('it computes versionSort for simple version', function(assert) {
+  assert.deepEqual(this.subject({version: 'v1'}).get('versionSort'),['00000000v1']);
+});
+
+test('it computes versionSort for major.minor.patch version', function(assert) {
+  let version = this.subject({version: 'v1.2.3'});
+  assert.deepEqual(version.get('versionSort'),['00000000v1','0000000002','0000000003']);
+});
+
+test('it computes versionSort for major.minor.patch-dev version', function(assert) {
+  let version = this.subject({version: 'v1.2.3-dev'});
+  assert.deepEqual(version.get('versionSort'),['00000000v1','0000000002','0000000003','0000000dev']);
+});

--- a/tests/unit/models/workflow-version-test.js
+++ b/tests/unit/models/workflow-version-test.js
@@ -47,6 +47,10 @@ test('it computes versionTag', function(assert) {
   assert.equal(version.get('versionTag'),'wf-tag/v3.2');
 });
 
+test('it computes versionSort for empty', function(assert) {
+  assert.deepEqual(this.subject({version: ''}).get('versionSort'),null);
+});
+
 test('it computes versionSort for simple version', function(assert) {
   assert.deepEqual(this.subject({version: 'v1'}).get('versionSort'),['00000000v1']);
 });


### PR DESCRIPTION
Adds versionSort computed field to workflow-version following the
sorting pattern used in bespin-api for sorting workflow-versions.
Changes version sorting to use this new field for routes:
- /new/select-workflow-version/<workflow_id> - select a workflow version
- /workflows - lists workflow versions for each workflow

Started using @each annotation to populate 'version' field in computed lists:
https://guides.emberjs.com/v2.12.0/object-model/computed-properties-and-aggregate-data/
The bug in question was only visible when viewing cached workflow versions due to
sorting done by bespin-api and the 'version' fields being null during
sort('version') operation.

Added `ember-pad` to work around PhantomJS missing String.padStart.

Fixes #148